### PR TITLE
Fix/remove controlzex nuget reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.8.1-beta.1] - 2024-08-24
+
+### Changed
+
+- Removes `ControlzEx` NuGet package reference
+- References `Microsoft.Xaml.Behaviors.Wpf` to fix issues related to XAML behaviors
+
+### Fixed
+
+- Calculates correct system menu position (takes DPI scaling into account)
+
+
 ## [v2.8.0-beta.1] - 2024-07-25
 
 ### Changed

--- a/sourcecodes/FSV.AdServices.Abstractions/FSV.AdServices.Abstractions.csproj
+++ b/sourcecodes/FSV.AdServices.Abstractions/FSV.AdServices.Abstractions.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>FSV.AdServices.Abstractions</AssemblyTitle>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.AdServices/FSV.AdServices.csproj
+++ b/sourcecodes/FSV.AdServices/FSV.AdServices.csproj
@@ -14,11 +14,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.AdServices</AssemblyTitle>
-    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Business/FSV.Business.csproj
+++ b/sourcecodes/FSV.Business/FSV.Business.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>FSV.Business</AssemblyTitle>
-    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Configuration.Abstractions/FSV.Configuration.Abstractions.csproj
+++ b/sourcecodes/FSV.Configuration.Abstractions/FSV.Configuration.Abstractions.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
     <TargetFramework>net8.0</TargetFramework>

--- a/sourcecodes/FSV.Configuration/FSV.Configuration.csproj
+++ b/sourcecodes/FSV.Configuration/FSV.Configuration.csproj
@@ -18,11 +18,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.Configuration</AssemblyTitle>
-    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Console/FSV.Console.csproj
+++ b/sourcecodes/FSV.Console/FSV.Console.csproj
@@ -19,11 +19,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.Console</AssemblyTitle>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Crypto.Abstractions/FSV.Crypto.Abstractions.csproj
+++ b/sourcecodes/FSV.Crypto.Abstractions/FSV.Crypto.Abstractions.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Authors>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecuriyViewer</Product>
     <TargetFramework>net8.0</TargetFramework>

--- a/sourcecodes/FSV.Crypto/FSV.Crypto.csproj
+++ b/sourcecodes/FSV.Crypto/FSV.Crypto.csproj
@@ -14,11 +14,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.Crypto</AssemblyTitle>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecuriyViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.CsvExporter/FSV.CsvExporter.csproj
+++ b/sourcecodes/FSV.CsvExporter/FSV.CsvExporter.csproj
@@ -14,11 +14,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.CsvExporter</AssemblyTitle>
-    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Database/FSV.Database.csproj
+++ b/sourcecodes/FSV.Database/FSV.Database.csproj
@@ -14,11 +14,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.Database</AssemblyTitle>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.EMailService/FSV.EMailService.csproj
+++ b/sourcecodes/FSV.EMailService/FSV.EMailService.csproj
@@ -14,11 +14,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.EMailService</AssemblyTitle>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.ExcelExporter/FSV.ExcelExporter.csproj
+++ b/sourcecodes/FSV.ExcelExporter/FSV.ExcelExporter.csproj
@@ -14,11 +14,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.ExcelExporter</AssemblyTitle>
-    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Extensions.DependencyInjection/FSV.Extensions.DependencyInjection.csproj
+++ b/sourcecodes/FSV.Extensions.DependencyInjection/FSV.Extensions.DependencyInjection.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Authors>G-TAC</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <DelaySign>false</DelaySign>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <LangVersion>latest</LangVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>

--- a/sourcecodes/FSV.Extensions.Logging/FSV.Extensions.Logging.csproj
+++ b/sourcecodes/FSV.Extensions.Logging/FSV.Extensions.Logging.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>FSV.Extensions.Logging</AssemblyTitle>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Extensions.Serialization/FSV.Extensions.Serialization.csproj
+++ b/sourcecodes/FSV.Extensions.Serialization/FSV.Extensions.Serialization.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Authors>G-TAC</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <LangVersion>latest</LangVersion>
     <Product>FolderSecurityViewer</Product>
     <TargetFramework>net8.0</TargetFramework>

--- a/sourcecodes/FSV.Extensions.WindowConfiguration/FSV.Extensions.WindowConfiguration.csproj
+++ b/sourcecodes/FSV.Extensions.WindowConfiguration/FSV.Extensions.WindowConfiguration.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>FSV.Extensions.Configuration</AssemblyTitle>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>
   <ItemGroup>

--- a/sourcecodes/FSV.FileSystem.Interop.Abstractions/FSV.FileSystem.Interop.Abstractions.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop.Abstractions/FSV.FileSystem.Interop.Abstractions.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Authors>G-TAC</Authors>
     <Company>G-TAC</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <LangVersion>latest</LangVersion>
     <PackageVersion>2.4.4</PackageVersion>
     <Product>FolderSecurityViewer</Product>

--- a/sourcecodes/FSV.FileSystem.Interop.Core.Abstractions/FSV.FileSystem.Interop.Core.Abstractions.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop.Core.Abstractions/FSV.FileSystem.Interop.Core.Abstractions.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Authors>Matthias Friedrich</Authors>
     <Company>G-TAC</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <LangVersion>latest</LangVersion>
     <PackageVersion>2.4.4</PackageVersion>
     <Product>FolderSecurityViewer</Product>

--- a/sourcecodes/FSV.FileSystem.Interop.Core/FSV.FileSystem.Interop.Core.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop.Core/FSV.FileSystem.Interop.Core.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Authors>Matthias Friedrich</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <LangVersion>latest</LangVersion>
     <PackageVersion>2.4.4</PackageVersion>
     <Product>FolderSecurityViewer</Product>

--- a/sourcecodes/FSV.FileSystem.Interop/FSV.FileSystem.Interop.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop/FSV.FileSystem.Interop.csproj
@@ -17,12 +17,12 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.FileSystem.Interop</AssemblyTitle>
-    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Authors>Matthias Friedrich</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.HtmlExporter/FSV.HtmlExporter.csproj
+++ b/sourcecodes/FSV.HtmlExporter/FSV.HtmlExporter.csproj
@@ -12,11 +12,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.HtmlExporter</AssemblyTitle>
-    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>

--- a/sourcecodes/FSV.Models/FSV.Models.csproj
+++ b/sourcecodes/FSV.Models/FSV.Models.csproj
@@ -14,11 +14,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.Models</AssemblyTitle>
-    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Resources/FSV.Resources.csproj
+++ b/sourcecodes/FSV.Resources/FSV.Resources.csproj
@@ -17,8 +17,8 @@
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Product>FolderSecurityViewer</Product>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
-    <FileVersion>2.8.0.0</FileVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <AnalysisLevel>none</AnalysisLevel>
   </PropertyGroup>

--- a/sourcecodes/FSV.Security/FSV.Security.csproj
+++ b/sourcecodes/FSV.Security/FSV.Security.csproj
@@ -10,11 +10,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.Security</AssemblyTitle>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.ShareServices/FSV.ShareServices.csproj
+++ b/sourcecodes/FSV.ShareServices/FSV.ShareServices.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Authors>G-TAC</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <LangVersion>latest</LangVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>

--- a/sourcecodes/FSV.Templates/FSV.Templates.csproj
+++ b/sourcecodes/FSV.Templates/FSV.Templates.csproj
@@ -14,11 +14,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.Templates</AssemblyTitle>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.ViewModel/FSV.ViewModel.csproj
+++ b/sourcecodes/FSV.ViewModel/FSV.ViewModel.csproj
@@ -20,11 +20,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.ViewModel</AssemblyTitle>
-    <AssemblyVersion>2.8.0</AssemblyVersion>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.0</FileVersion>
+    <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FolderSecurityViewer/Controls/CustomWindow.cs
+++ b/sourcecodes/FolderSecurityViewer/Controls/CustomWindow.cs
@@ -17,13 +17,10 @@
 namespace FolderSecurityViewer.Controls
 {
     using System.Windows;
-    using ControlzEx.Behaviors;
-    using Microsoft.Xaml.Behaviors;
 
     public class CustomWindow : Window
     {
-        public static readonly DependencyProperty StartLocationProperty =
-            DependencyProperty.Register("StartLocation", typeof(WindowStartupLocation), typeof(CustomWindow), new PropertyMetadata(WindowStartupLocation.Manual, OnStartLocationChanged));
+        public static readonly DependencyProperty StartLocationProperty = DependencyProperty.Register(nameof(StartLocation), typeof(WindowStartupLocation), typeof(CustomWindow), new PropertyMetadata(WindowStartupLocation.Manual, OnStartLocationChanged));
 
         public CustomWindow()
         {
@@ -46,17 +43,6 @@ namespace FolderSecurityViewer.Controls
             {
                 window.WindowStartupLocation = window.StartLocation;
             }
-        }
-
-        private void InitializeWindowChromeBehavior()
-        {
-            var behavior = new WindowChromeBehavior();
-            //BindingOperations.SetBinding(behavior, WindowChromeBehavior.EnableMinimizeProperty, new Binding { Path = new PropertyPath(ShowMinButtonProperty), Source = this });
-            //BindingOperations.SetBinding(behavior, WindowChromeBehavior.EnableMaxRestoreProperty, new Binding { Path = new PropertyPath(ShowMaxRestoreButtonProperty), Source = this });
-
-            // this.SetBinding(IsNCActiveProperty, new Binding { Path = new PropertyPath(WindowChromeBehavior.IsNCActiveProperty), Source = behavior });
-
-            Interaction.GetBehaviors(this).Add(behavior);
         }
     }
 }

--- a/sourcecodes/FolderSecurityViewer/FolderSecurityViewer.csproj
+++ b/sourcecodes/FolderSecurityViewer/FolderSecurityViewer.csproj
@@ -70,8 +70,8 @@
     <Resource Include="Resources\Images\AppIcon.ico" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ControlzEx">
-      <Version>6.0.0</Version>
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
+      <Version>1.1.122</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Extensions.Logging">
       <Version>8.0.0</Version>

--- a/sourcecodes/FolderSecurityViewer/FolderSecurityViewer.csproj
+++ b/sourcecodes/FolderSecurityViewer/FolderSecurityViewer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Authors>Carsten Schäfer, Matthias Friedrich, and Ritesh Gite</Authors>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
@@ -13,19 +13,17 @@
     <Title>FolderSecurityViewer</Title>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
-    <Version>2.8.0</Version>
-    <AssemblyVersion>2.8.0</AssemblyVersion>
-    <FileVersion>2.8.0</FileVersion>
+    <Version>2.8.1</Version>
+    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <FileVersion>2.8.1</FileVersion>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <LangVersion>latest</LangVersion>
-    <Optimize>true</Optimize>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Optimize>False</Optimize>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
-    <LangVersion>latest</LangVersion>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Resources\Images\AppIcon.ico</ApplicationIcon>

--- a/sourcecodes/FolderSecurityViewer/Helpers/WindowDragBehavior.cs
+++ b/sourcecodes/FolderSecurityViewer/Helpers/WindowDragBehavior.cs
@@ -1,4 +1,4 @@
-﻿// FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
+// FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
 // Copyright (C) 2015 - 2024  Carsten Schäfer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
@@ -21,21 +21,21 @@ namespace FolderSecurityViewer.Helpers
 
     public static class WindowDragBehavior
     {
-        public static readonly DependencyProperty LeftMouseButtonDrag = DependencyProperty.RegisterAttached("LeftMouseButtonDrag",
+        public static readonly DependencyProperty LeftMouseButtonDragProperty = DependencyProperty.RegisterAttached("LeftMouseButtonDrag",
             typeof(Window), typeof(WindowDragBehavior),
-            new UIPropertyMetadata(null, OnLeftMouseButtonDragChanged));
+            new UIPropertyMetadata(null, LeftMouseButtonDragPropertyChangedCallback));
 
         public static Window GetLeftMouseButtonDrag(DependencyObject obj)
         {
-            return (Window)obj.GetValue(LeftMouseButtonDrag);
+            return (Window)obj.GetValue(LeftMouseButtonDragProperty);
         }
 
         public static void SetLeftMouseButtonDrag(DependencyObject obj, Window window)
         {
-            obj.SetValue(LeftMouseButtonDrag, window);
+            obj.SetValue(LeftMouseButtonDragProperty, window);
         }
 
-        private static void OnLeftMouseButtonDragChanged(object sender, DependencyPropertyChangedEventArgs e)
+        private static void LeftMouseButtonDragPropertyChangedCallback(object sender, DependencyPropertyChangedEventArgs e)
         {
             if (sender is UIElement element)
             {
@@ -45,8 +45,7 @@ namespace FolderSecurityViewer.Helpers
 
         private static void ButtonDown(object sender, MouseButtonEventArgs e)
         {
-            var element = sender as UIElement;
-            if (element.GetValue(LeftMouseButtonDrag) is Window targetWindow)
+            if (sender is UIElement element && element.GetValue(LeftMouseButtonDragProperty) is Window targetWindow)
             {
                 targetWindow.DragMove();
             }


### PR DESCRIPTION
### Changes

- Removes the `ControlzEx` NuGet package reference
- References `Microsoft.Xaml.Behaviors.Wpf` to fix issues related to XAML behaviors

### Fixes

- Calculates correct system menu position (takes DPI scaling into account) in `ShowSystemMenuBehavior`