### PR TITLE
Migrates solution to .NET 9.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install .NET Core
+      - name: Install .NET 9
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 9.0.x

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,30 +2,28 @@ name: .NET Core Desktop
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
-
   build:
-
-    runs-on: windows-latest  # For a list of available runner types, refer to
-                             # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+    runs-on: windows-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Install .NET Core
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.0.x
+      - name: Install .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+          cache: true
 
-    - name: Execute unit tests
-      run: |
-        cd sourcecodes
-        dotnet build --configuration Release
-        dotnet test ./FolderSecurityViewer.sln --framework net8.0-windows --configuration Release
+      - name: Execute unit tests
+        run: |
+          cd sourcecodes
+          dotnet build --configuration Release
+          dotnet test ./FolderSecurityViewer.sln --framework net9.0-windows --configuration Release

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 9.0.x
-          cache: true
+          # cache: true
 
       - name: Execute unit tests
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.9.0-beta.1] - 2025-11-11
+
+### Changed
+
+- Changed the target framework to .NET 9.0 across all projects [#12](https://github.com/carstenschaefer/FolderSecurityViewer/pull/12)
+- Updated GitHub Actions workflow to use .NET 9.0 [#12](https://github.com/carstenschaefer/FolderSecurityViewer/pull/12)
+- Updated all NuGet packackages in the whole solution [#12](https://github.com/carstenschaefer/FolderSecurityViewer/pull/12)
+- Updated test framework target from net8.0-windows to net9.0-windows [#12](https://github.com/carstenschaefer/FolderSecurityViewer/pull/12)
+
+
 ## [v2.8.1-beta.1] - 2024-08-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v2.9.0-beta.1] - 2025-11-11
+## [v2.9.0-beta.1] - 2025-11-13
+
+This release upgrades the entire solution to .NET 9.0, bringing performance improvements and access to the latest framework features. All dependencies have been updated.
 
 ### Changed
 
 - Changed the target framework to .NET 9.0 across all projects [#12](https://github.com/carstenschaefer/FolderSecurityViewer/pull/12)
 - Updated GitHub Actions workflow to use .NET 9.0 [#12](https://github.com/carstenschaefer/FolderSecurityViewer/pull/12)
-- Updated all NuGet packackages in the whole solution [#12](https://github.com/carstenschaefer/FolderSecurityViewer/pull/12)
+- Updated all NuGet packages in the whole solution [#12](https://github.com/carstenschaefer/FolderSecurityViewer/pull/12)
 - Updated test framework target from net8.0-windows to net9.0-windows [#12](https://github.com/carstenschaefer/FolderSecurityViewer/pull/12)
-
+- Migrated unit tests from xUnit to MSTest framework with improved assertions [#12](https://github.com/carstenschaefer/FolderSecurityViewer/pull/12)
 
 ## [v2.8.1-beta.1] - 2024-08-24
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ dotnet build ./FolderSecurityViewer.sln --configuration Release
 
 ````bash
 $ dotnet clean && dotnet build
-$ dotnet test --framework net8.0-windows
+$ dotnet test --framework net9.0-windows
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,16 @@ If you want to automate your NTFS permissions reporting, you can use the Command
 
 The application can be compiled on Windows, and depends on the following Frameworks and utilities:
 
-* .NET Framework 8.0 SDK
-* Optional: Visual Studio 2022
-* MSBuild version 17.9.8 or above
+* .NET Framework 9.0 SDK
+* Optional: Visual Studio 2026
 
 ### Platform compatibility
 
-Ensure your target platform is supported by .NET 8; check the supported OS versions in the  [.NET 8 Release Notes](https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md#net-8---supported-os-versions). If you need a build compatible with Windows 7 or 8, please refer to version [v2.7.0-beta.1](https://github.com/carstenschaefer/FolderSecurityViewer/releases/tag/v2.7.0-beta.1), which depends on .NET Framework 4.7 and Visual Studio.
+Ensure your target platform is supported by .NET 9; check the supported OS versions in the  [.NET 9 Release Notes](https://github.com/dotnet/core/blob/main/release-notes/9.0/supported-os.md).
+
+* If you need a built targeting .NET 8, please refer to version [v2.8.1-beta.1](https://github.com/carstenschaefer/FolderSecurityViewer/releases/tag/v2.8.1-beta.1).
+
+* If you need a build compatible with Windows 7 or 8, please refer to version [v2.7.0-beta.1](https://github.com/carstenschaefer/FolderSecurityViewer/releases/tag/v2.7.0-beta.1), which depends on .NET Framework 4.7 and Visual Studio.
 
 
 ### Build
@@ -77,4 +80,4 @@ $ dotnet test --framework net9.0-windows
 ````
 
 
-Copyright (C) 2015 - 2024 by Carsten Schäfer, Matthias Friedrich, and Ritesh Gite
+Copyright (C) 2015 - 2025 by Carsten Schäfer, Matthias Friedrich, and Ritesh Gite

--- a/sourcecodes/FSV.ActiveDirectoryServices.TestAbstractionLayer/FSV.ActiveDirectoryServices.TestAbstractionLayer.csproj
+++ b/sourcecodes/FSV.ActiveDirectoryServices.TestAbstractionLayer/FSV.ActiveDirectoryServices.TestAbstractionLayer.csproj
@@ -8,7 +8,7 @@
   <PropertyGroup>
     <AssemblyTitle>FSV.ActiveDirectoryServices.TestAbstractionLayer</AssemblyTitle>
     <Product>FSV.ActiveDirectoryServices.TestAbstractionLayer</Product>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>

--- a/sourcecodes/FSV.ActiveDirectoryServices.TestAbstractionLayer/FSV.ActiveDirectoryServices.TestAbstractionLayer.csproj
+++ b/sourcecodes/FSV.ActiveDirectoryServices.TestAbstractionLayer/FSV.ActiveDirectoryServices.TestAbstractionLayer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <LangVersion>latest</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/sourcecodes/FSV.ActiveDirectoryServices.TestAbstractionLayer/FSV.ActiveDirectoryServices.TestAbstractionLayer.csproj
+++ b/sourcecodes/FSV.ActiveDirectoryServices.TestAbstractionLayer/FSV.ActiveDirectoryServices.TestAbstractionLayer.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="YamlDotNet">
-      <Version>16.0.0</Version>
+      <Version>16.3.0</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.AdServices.Abstractions/FSV.AdServices.Abstractions.csproj
+++ b/sourcecodes/FSV.AdServices.Abstractions/FSV.AdServices.Abstractions.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>FSV.AdServices.Abstractions</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.AdServices.Abstractions/FSV.AdServices.Abstractions.csproj
+++ b/sourcecodes/FSV.AdServices.Abstractions/FSV.AdServices.Abstractions.csproj
@@ -9,7 +9,7 @@
     <AssemblyTitle>FSV.AdServices.Abstractions</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.AdServices.Abstractions/FSV.AdServices.Abstractions.csproj
+++ b/sourcecodes/FSV.AdServices.Abstractions/FSV.AdServices.Abstractions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/sourcecodes/FSV.AdServices.UnitTest/ActiveDirectoryLdapUtilityTest.cs
+++ b/sourcecodes/FSV.AdServices.UnitTest/ActiveDirectoryLdapUtilityTest.cs
@@ -1,4 +1,4 @@
-﻿// FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
+// FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
 // Copyright (C) 2015 - 2024  Carsten Schäfer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
@@ -32,8 +32,8 @@ namespace FSV.AdServices.UnitTest
 
             // Assert
             Assert.IsNotNull(actual);
-            Assert.AreEqual(3, actual.Length);
-            Assert.AreEqual(actual[0], "DN=Users");
+            Assert.HasCount(3, actual);
+            Assert.AreEqual("DN=Users", actual[0]);
         }
     }
 }

--- a/sourcecodes/FSV.AdServices.UnitTest/FSV.AdServices.UnitTest.csproj
+++ b/sourcecodes/FSV.AdServices.UnitTest/FSV.AdServices.UnitTest.csproj
@@ -15,16 +15,16 @@
     <Product>FSV.AdServices.UnitTest</Product>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
-    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSV.ActiveDirectoryServices.TestAbstractionLayer\FSV.ActiveDirectoryServices.TestAbstractionLayer.csproj" />

--- a/sourcecodes/FSV.AdServices.UnitTest/FSV.AdServices.UnitTest.csproj
+++ b/sourcecodes/FSV.AdServices.UnitTest/FSV.AdServices.UnitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <LangVersion>latest</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>

--- a/sourcecodes/FSV.AdServices.UnitTest/FSV.AdServices.UnitTest.csproj
+++ b/sourcecodes/FSV.AdServices.UnitTest/FSV.AdServices.UnitTest.csproj
@@ -10,7 +10,7 @@
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.AdServices.UnitTest</AssemblyTitle>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <FileVersion>1.0.0.0</FileVersion>
     <Product>FSV.AdServices.UnitTest</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.AdServices/FSV.AdServices.csproj
+++ b/sourcecodes/FSV.AdServices/FSV.AdServices.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/sourcecodes/FSV.AdServices/FSV.AdServices.csproj
+++ b/sourcecodes/FSV.AdServices/FSV.AdServices.csproj
@@ -14,11 +14,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.AdServices</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.AdServices/FSV.AdServices.csproj
+++ b/sourcecodes/FSV.AdServices/FSV.AdServices.csproj
@@ -33,11 +33,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations">
-      <Version>2024.2.0</Version>
+      <Version>2025.2.2</Version>
     </PackageReference>
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="System.DirectoryServices" Version="8.0.0" />
-    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="System.DirectoryServices" Version="10.0.0" />
+    <PackageReference Include="System.DirectoryServices.AccountManagement" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.AdServices/FSV.AdServices.csproj
+++ b/sourcecodes/FSV.AdServices/FSV.AdServices.csproj
@@ -16,7 +16,7 @@
     <AssemblyTitle>FSV.AdServices</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.Business.UnitTest/FSV.Business.UnitTest.csproj
+++ b/sourcecodes/FSV.Business.UnitTest/FSV.Business.UnitTest.csproj
@@ -11,7 +11,7 @@
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
     <Product>FSV.Business.UnitTest</Product>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />

--- a/sourcecodes/FSV.Business.UnitTest/FSV.Business.UnitTest.csproj
+++ b/sourcecodes/FSV.Business.UnitTest/FSV.Business.UnitTest.csproj
@@ -14,10 +14,13 @@
     <TargetFramework>net9.0-windows</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSV.AdServices\FSV.AdServices.csproj" />

--- a/sourcecodes/FSV.Business.UnitTest/FSV.Business.UnitTest.csproj
+++ b/sourcecodes/FSV.Business.UnitTest/FSV.Business.UnitTest.csproj
@@ -3,7 +3,7 @@
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.Business.UnitTest</AssemblyTitle>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <FileVersion>1.0.0.0</FileVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>

--- a/sourcecodes/FSV.Business/FSV.Business.csproj
+++ b/sourcecodes/FSV.Business/FSV.Business.csproj
@@ -11,7 +11,7 @@
     <AssemblyTitle>FSV.Business</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.Business/FSV.Business.csproj
+++ b/sourcecodes/FSV.Business/FSV.Business.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/sourcecodes/FSV.Business/FSV.Business.csproj
+++ b/sourcecodes/FSV.Business/FSV.Business.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>FSV.Business</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Business/FSV.Business.csproj
+++ b/sourcecodes/FSV.Business/FSV.Business.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.Configuration.Abstractions/FSV.Configuration.Abstractions.csproj
+++ b/sourcecodes/FSV.Configuration.Abstractions/FSV.Configuration.Abstractions.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
     <TargetFramework>net9.0</TargetFramework>

--- a/sourcecodes/FSV.Configuration.Abstractions/FSV.Configuration.Abstractions.csproj
+++ b/sourcecodes/FSV.Configuration.Abstractions/FSV.Configuration.Abstractions.csproj
@@ -7,7 +7,7 @@
     <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Version>2.4.1</Version>
   </PropertyGroup>
 </Project>

--- a/sourcecodes/FSV.Configuration.Abstractions/FSV.Configuration.Abstractions.csproj
+++ b/sourcecodes/FSV.Configuration.Abstractions/FSV.Configuration.Abstractions.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.Configuration.UnitTest/ConfigurationManagerTest.cs
+++ b/sourcecodes/FSV.Configuration.UnitTest/ConfigurationManagerTest.cs
@@ -1,5 +1,5 @@
 // FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
-// Copyright (C) 2015 - 2024  Carsten Sch‰fer, Matthias Friedrich, and Ritesh Gite
+// Copyright (C) 2015 - 2024  Carsten Sch√§fer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -55,7 +55,7 @@ namespace FSV.Configuration.UnitTest
             }
 
             // Assert
-            Assert.ThrowsException<ConfigurationException>(Act);
+            Assert.Throws<ConfigurationException>(Act);
         }
     }
 }

--- a/sourcecodes/FSV.Configuration.UnitTest/FSV.Configuration.UnitTest.csproj
+++ b/sourcecodes/FSV.Configuration.UnitTest/FSV.Configuration.UnitTest.csproj
@@ -20,9 +20,9 @@
     <ProjectReference Include="..\FSV.Extensions.Logging\FSV.Extensions.Logging.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.Configuration.UnitTest/FSV.Configuration.UnitTest.csproj
+++ b/sourcecodes/FSV.Configuration.UnitTest/FSV.Configuration.UnitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <LangVersion>default</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>

--- a/sourcecodes/FSV.Configuration.UnitTest/FSV.Configuration.UnitTest.csproj
+++ b/sourcecodes/FSV.Configuration.UnitTest/FSV.Configuration.UnitTest.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <AssemblyTitle>FSV.Configuration.UnitTest</AssemblyTitle>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <FileVersion>1.0.0.0</FileVersion>
     <Product>FSV.Configuration.UnitTest</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Configuration/FSV.Configuration.csproj
+++ b/sourcecodes/FSV.Configuration/FSV.Configuration.csproj
@@ -5,7 +5,7 @@
     <OutputType>Library</OutputType>
     <RestorePackages>true</RestorePackages>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/sourcecodes/FSV.Configuration/FSV.Configuration.csproj
+++ b/sourcecodes/FSV.Configuration/FSV.Configuration.csproj
@@ -36,6 +36,7 @@
     <EmbeddedResource Include="Defaults\ShareConfig.xml" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageReference Include="System.Data.SQLite">
       <Version>2.0.2</Version>
     </PackageReference>

--- a/sourcecodes/FSV.Configuration/FSV.Configuration.csproj
+++ b/sourcecodes/FSV.Configuration/FSV.Configuration.csproj
@@ -37,9 +37,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Data.SQLite">
-      <Version>1.0.118</Version>
+      <Version>2.0.2</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSV.Configuration.Abstractions\FSV.Configuration.Abstractions.csproj" />

--- a/sourcecodes/FSV.Configuration/FSV.Configuration.csproj
+++ b/sourcecodes/FSV.Configuration/FSV.Configuration.csproj
@@ -20,7 +20,7 @@
     <AssemblyTitle>FSV.Configuration</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.Configuration/FSV.Configuration.csproj
+++ b/sourcecodes/FSV.Configuration/FSV.Configuration.csproj
@@ -18,11 +18,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.Configuration</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Console.UnitTest/FSV.Console.UnitTest.csproj
+++ b/sourcecodes/FSV.Console.UnitTest/FSV.Console.UnitTest.csproj
@@ -11,16 +11,16 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>17.10.0</Version>
+      <Version>18.0.1</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.20.70</Version>
+      <Version>4.20.72</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>3.5.0</Version>
+      <Version>4.0.2</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.5.0</Version>
+      <Version>4.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/sourcecodes/FSV.Console.UnitTest/FSV.Console.UnitTest.csproj
+++ b/sourcecodes/FSV.Console.UnitTest/FSV.Console.UnitTest.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyTitle>FSV.Console.UnitTest</AssemblyTitle>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <FileVersion>1.0.0.0</FileVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputType>Library</OutputType>

--- a/sourcecodes/FSV.Console.UnitTest/FSV.Console.UnitTest.csproj
+++ b/sourcecodes/FSV.Console.UnitTest/FSV.Console.UnitTest.csproj
@@ -7,7 +7,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputType>Library</OutputType>
     <Product>FSV.Console.UnitTest</Product>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/sourcecodes/FSV.Console/FSV.Console.csproj
+++ b/sourcecodes/FSV.Console/FSV.Console.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Exe</OutputType>
     <AssemblyName>fsv</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/sourcecodes/FSV.Console/FSV.Console.csproj
+++ b/sourcecodes/FSV.Console/FSV.Console.csproj
@@ -68,17 +68,17 @@
       <Version>1.1.1</Version>
     </PackageReference>
     <PackageReference Include="Prism.Core">
-      <Version>8.1.97</Version>
+      <Version>9.0.537</Version>
     </PackageReference>
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Data.SQLite.Core">
-      <Version>1.0.118</Version>
+      <Version>1.0.119</Version>
     </PackageReference>
     <PackageReference Include="System.Data.SQLite.EF6">
-      <Version>1.0.118</Version>
+      <Version>2.0.2</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Connected Services\" />

--- a/sourcecodes/FSV.Console/FSV.Console.csproj
+++ b/sourcecodes/FSV.Console/FSV.Console.csproj
@@ -21,7 +21,7 @@
     <AssemblyTitle>FSV.Console</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.Console/FSV.Console.csproj
+++ b/sourcecodes/FSV.Console/FSV.Console.csproj
@@ -19,11 +19,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.Console</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Crypto.Abstractions/FSV.Crypto.Abstractions.csproj
+++ b/sourcecodes/FSV.Crypto.Abstractions/FSV.Crypto.Abstractions.csproj
@@ -4,7 +4,7 @@
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Authors>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.Crypto.Abstractions/FSV.Crypto.Abstractions.csproj
+++ b/sourcecodes/FSV.Crypto.Abstractions/FSV.Crypto.Abstractions.csproj
@@ -9,7 +9,7 @@
     <FileVersion>2.8.1</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecuriyViewer</Product>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Version>2.4.1</Version>
   </PropertyGroup>
 </Project>

--- a/sourcecodes/FSV.Crypto.Abstractions/FSV.Crypto.Abstractions.csproj
+++ b/sourcecodes/FSV.Crypto.Abstractions/FSV.Crypto.Abstractions.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Authors>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecuriyViewer</Product>
     <TargetFramework>net9.0</TargetFramework>

--- a/sourcecodes/FSV.Crypto.UnitTest/FSV.Crypto.UnitTest.csproj
+++ b/sourcecodes/FSV.Crypto.UnitTest/FSV.Crypto.UnitTest.csproj
@@ -8,7 +8,7 @@
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
     <Product>FSV.Crypto.UnitTest</Product>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSV.Crypto.Abstractions\FSV.Crypto.Abstractions.csproj" />

--- a/sourcecodes/FSV.Crypto.UnitTest/FSV.Crypto.UnitTest.csproj
+++ b/sourcecodes/FSV.Crypto.UnitTest/FSV.Crypto.UnitTest.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyTitle>FSV.Crypto.UnitTest</AssemblyTitle>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <FileVersion>1.0.0.0</FileVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>latest</LangVersion>

--- a/sourcecodes/FSV.Crypto.UnitTest/FSV.Crypto.UnitTest.csproj
+++ b/sourcecodes/FSV.Crypto.UnitTest/FSV.Crypto.UnitTest.csproj
@@ -16,13 +16,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>17.10.0</Version>
+      <Version>18.0.1</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>3.5.0</Version>
+      <Version>4.0.2</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.5.0</Version>
+      <Version>4.0.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.Crypto.UnitTest/SecureTest.cs
+++ b/sourcecodes/FSV.Crypto.UnitTest/SecureTest.cs
@@ -1,5 +1,5 @@
 // FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
-// Copyright (C) 2015 - 2024  Carsten Sch‰fer, Matthias Friedrich, and Ritesh Gite
+// Copyright (C) 2015 - 2024  Carsten Sch√§fer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -26,7 +26,7 @@ namespace FSV.Crypto.UnitTest
     [TestClass]
     public class SecureTest
     {
-        private const string password = "Abc#123";
+        private const string Password = "Abc#123";
 
         [TestMethod]
         public void Secure_EncryptFromSecureString_Empty_test()
@@ -42,18 +42,18 @@ namespace FSV.Crypto.UnitTest
         public void Secure_EncryptFromSecureString_Entropy_test()
         {
             ISecure secure = new Secure();
-            SecureString secureString = this.GetSecureString(password);
+            SecureString secureString = this.GetSecureString(Password);
             string encrypted = secure.EncryptFromSecureString(secureString);
 
             Assert.IsNotNull(encrypted);
-            Assert.IsFalse(password.Equals(encrypted));
+            Assert.IsFalse(Password.Equals(encrypted));
         }
 
         [TestMethod]
         public void Secure_EncryptFromSecureString_NoEntropy_test()
         {
             ISecure secure = new Secure();
-            SecureString secureString = this.GetSecureString(password);
+            SecureString secureString = this.GetSecureString(Password);
 
             string encryptedWithEntropy = secure.EncryptFromSecureString(secureString);
             string encryptedWithoutEntropy = secure.EncryptFromSecureString(secureString, false);
@@ -79,10 +79,10 @@ namespace FSV.Crypto.UnitTest
         {
             ISecure secure = new Secure();
 
-            string encrypted = secure.EncryptFromSecureString(this.GetSecureString(password));
+            string encrypted = secure.EncryptFromSecureString(this.GetSecureString(Password));
             SecureString decrypted = secure.DecryptToSecureString(encrypted);
 
-            Assert.AreEqual(password.Length, decrypted.Length);
+            Assert.AreEqual(Password.Length, decrypted.Length);
         }
 
         [TestMethod]
@@ -90,10 +90,10 @@ namespace FSV.Crypto.UnitTest
         {
             ISecure secure = new Secure();
 
-            string encrypted = secure.EncryptFromSecureString(this.GetSecureString(password), false);
+            string encrypted = secure.EncryptFromSecureString(this.GetSecureString(Password), false);
             SecureString decrypted = secure.DecryptToSecureString(encrypted, false);
 
-            Assert.AreEqual(password.Length, decrypted.Length);
+            Assert.AreEqual(Password.Length, decrypted.Length);
         }
 
         [TestMethod]
@@ -101,9 +101,9 @@ namespace FSV.Crypto.UnitTest
         {
             ISecure secure = new Secure();
 
-            string encrypted = secure.EncryptFromSecureString(this.GetSecureString(password), false);
+            string encrypted = secure.EncryptFromSecureString(this.GetSecureString(Password), false);
 
-            Assert.ThrowsException<CryptographicException>(() => secure.DecryptToSecureString(encrypted));
+            Assert.Throws<CryptographicException>(() => secure.DecryptToSecureString(encrypted));
         }
 
         [TestMethod]
@@ -111,16 +111,16 @@ namespace FSV.Crypto.UnitTest
         {
             ISecure secure = new Secure();
 
-            string encrypted = secure.EncryptFromSecureString(this.GetSecureString(password));
+            string encrypted = secure.EncryptFromSecureString(this.GetSecureString(Password));
 
-            Assert.ThrowsException<CryptographicException>(() => secure.DecryptToSecureString(encrypted, false));
+            Assert.Throws<CryptographicException>(() => secure.DecryptToSecureString(encrypted, false));
         }
 
         [TestMethod]
         public void Secure_GetBytes_test()
         {
             ISecure secure = new Secure();
-            using SecureString secureString = this.GetSecureString(password);
+            using SecureString secureString = this.GetSecureString(Password);
 
             IEnumerable<byte> bytes = secure.GetBytes(secureString);
 

--- a/sourcecodes/FSV.Crypto/FSV.Crypto.csproj
+++ b/sourcecodes/FSV.Crypto/FSV.Crypto.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/sourcecodes/FSV.Crypto/FSV.Crypto.csproj
+++ b/sourcecodes/FSV.Crypto/FSV.Crypto.csproj
@@ -16,7 +16,7 @@
     <AssemblyTitle>FSV.Crypto</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.Crypto/FSV.Crypto.csproj
+++ b/sourcecodes/FSV.Crypto/FSV.Crypto.csproj
@@ -14,11 +14,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.Crypto</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecuriyViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Crypto/FSV.Crypto.csproj
+++ b/sourcecodes/FSV.Crypto/FSV.Crypto.csproj
@@ -27,8 +27,8 @@
     <ProjectReference Include="..\FSV.Extensions.DependencyInjection\FSV.Extensions.DependencyInjection.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.CsvExporter/FSV.CsvExporter.csproj
+++ b/sourcecodes/FSV.CsvExporter/FSV.CsvExporter.csproj
@@ -14,11 +14,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.CsvExporter</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.CsvExporter/FSV.CsvExporter.csproj
+++ b/sourcecodes/FSV.CsvExporter/FSV.CsvExporter.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CsvHelper">
-      <Version>33.0.1</Version>
+      <Version>33.1.0</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.CsvExporter/FSV.CsvExporter.csproj
+++ b/sourcecodes/FSV.CsvExporter/FSV.CsvExporter.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/sourcecodes/FSV.CsvExporter/FSV.CsvExporter.csproj
+++ b/sourcecodes/FSV.CsvExporter/FSV.CsvExporter.csproj
@@ -16,7 +16,7 @@
     <AssemblyTitle>FSV.CsvExporter</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.Database.UnitTest/FSV.Database.UnitTest.csproj
+++ b/sourcecodes/FSV.Database.UnitTest/FSV.Database.UnitTest.csproj
@@ -15,13 +15,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>17.10.0</Version>
+      <Version>18.0.1</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>3.5.0</Version>
+      <Version>4.0.2</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.5.0</Version>
+      <Version>4.0.2</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.Database.UnitTest/FSV.Database.UnitTest.csproj
+++ b/sourcecodes/FSV.Database.UnitTest/FSV.Database.UnitTest.csproj
@@ -8,7 +8,7 @@
     <LangVersion>default</LangVersion>
     <OutputType>Library</OutputType>
     <Product>FSV.Database.UnitTest</Product>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSV.Database\FSV.Database.csproj" />

--- a/sourcecodes/FSV.Database.UnitTest/FSV.Database.UnitTest.csproj
+++ b/sourcecodes/FSV.Database.UnitTest/FSV.Database.UnitTest.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyTitle>FSV.Database.UnitTest</AssemblyTitle>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <FileVersion>1.0.0.0</FileVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>default</LangVersion>

--- a/sourcecodes/FSV.Database/FSV.Database.csproj
+++ b/sourcecodes/FSV.Database/FSV.Database.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/sourcecodes/FSV.Database/FSV.Database.csproj
+++ b/sourcecodes/FSV.Database/FSV.Database.csproj
@@ -53,8 +53,8 @@
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Data.SQLite">
-      <Version>1.0.118</Version>
+      <Version>2.0.2</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.Database/FSV.Database.csproj
+++ b/sourcecodes/FSV.Database/FSV.Database.csproj
@@ -14,11 +14,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.Database</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Database/FSV.Database.csproj
+++ b/sourcecodes/FSV.Database/FSV.Database.csproj
@@ -16,7 +16,7 @@
     <AssemblyTitle>FSV.Database</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.EMailService/FSV.EMailService.csproj
+++ b/sourcecodes/FSV.EMailService/FSV.EMailService.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/sourcecodes/FSV.EMailService/FSV.EMailService.csproj
+++ b/sourcecodes/FSV.EMailService/FSV.EMailService.csproj
@@ -16,7 +16,7 @@
     <AssemblyTitle>FSV.EMailService</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.EMailService/FSV.EMailService.csproj
+++ b/sourcecodes/FSV.EMailService/FSV.EMailService.csproj
@@ -14,11 +14,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.EMailService</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.ExcelExporter/FSV.ExcelExporter.csproj
+++ b/sourcecodes/FSV.ExcelExporter/FSV.ExcelExporter.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/sourcecodes/FSV.ExcelExporter/FSV.ExcelExporter.csproj
+++ b/sourcecodes/FSV.ExcelExporter/FSV.ExcelExporter.csproj
@@ -16,7 +16,7 @@
     <AssemblyTitle>FSV.ExcelExporter</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.ExcelExporter/FSV.ExcelExporter.csproj
+++ b/sourcecodes/FSV.ExcelExporter/FSV.ExcelExporter.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ClosedXML">
-      <Version>0.102.3</Version>
+      <Version>0.105.0</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.ExcelExporter/FSV.ExcelExporter.csproj
+++ b/sourcecodes/FSV.ExcelExporter/FSV.ExcelExporter.csproj
@@ -14,11 +14,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.ExcelExporter</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Extensions.DependencyInjection.UnitTest/FSV.Extensions.DependencyInjection.UnitTest.csproj
+++ b/sourcecodes/FSV.Extensions.DependencyInjection.UnitTest/FSV.Extensions.DependencyInjection.UnitTest.csproj
@@ -5,16 +5,16 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/sourcecodes/FSV.Extensions.DependencyInjection.UnitTest/FSV.Extensions.DependencyInjection.UnitTest.csproj
+++ b/sourcecodes/FSV.Extensions.DependencyInjection.UnitTest/FSV.Extensions.DependencyInjection.UnitTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>default</LangVersion>
   </PropertyGroup>

--- a/sourcecodes/FSV.Extensions.DependencyInjection/FSV.Extensions.DependencyInjection.csproj
+++ b/sourcecodes/FSV.Extensions.DependencyInjection/FSV.Extensions.DependencyInjection.csproj
@@ -3,7 +3,7 @@
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Authors>G-TAC</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <DelaySign>false</DelaySign>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>

--- a/sourcecodes/FSV.Extensions.DependencyInjection/FSV.Extensions.DependencyInjection.csproj
+++ b/sourcecodes/FSV.Extensions.DependencyInjection/FSV.Extensions.DependencyInjection.csproj
@@ -10,7 +10,7 @@
     <LangVersion>latest</LangVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/sourcecodes/FSV.Extensions.DependencyInjection/FSV.Extensions.DependencyInjection.csproj
+++ b/sourcecodes/FSV.Extensions.DependencyInjection/FSV.Extensions.DependencyInjection.csproj
@@ -18,7 +18,7 @@
     <AnalysisLevel>none</AnalysisLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.Extensions.DependencyInjection/FSV.Extensions.DependencyInjection.csproj
+++ b/sourcecodes/FSV.Extensions.DependencyInjection/FSV.Extensions.DependencyInjection.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Authors>G-TAC</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <DelaySign>false</DelaySign>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>

--- a/sourcecodes/FSV.Extensions.Logging/FSV.Extensions.Logging.csproj
+++ b/sourcecodes/FSV.Extensions.Logging/FSV.Extensions.Logging.csproj
@@ -18,15 +18,15 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Serilog">
-      <Version>4.0.0</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Extensions.Logging">
-      <Version>8.0.0</Version>
+      <Version>9.0.2</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.File">
-      <Version>6.0.0</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSV.Configuration.Abstractions\FSV.Configuration.Abstractions.csproj" />

--- a/sourcecodes/FSV.Extensions.Logging/FSV.Extensions.Logging.csproj
+++ b/sourcecodes/FSV.Extensions.Logging/FSV.Extensions.Logging.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>FSV.Extensions.Logging</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Extensions.Logging/FSV.Extensions.Logging.csproj
+++ b/sourcecodes/FSV.Extensions.Logging/FSV.Extensions.Logging.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/sourcecodes/FSV.Extensions.Logging/FSV.Extensions.Logging.csproj
+++ b/sourcecodes/FSV.Extensions.Logging/FSV.Extensions.Logging.csproj
@@ -10,7 +10,7 @@
     <AssemblyTitle>FSV.Extensions.Logging</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.Extensions.Serialization.UnitTest/FSV.Extensions.Serialization.UnitTest.csproj
+++ b/sourcecodes/FSV.Extensions.Serialization.UnitTest/FSV.Extensions.Serialization.UnitTest.csproj
@@ -3,7 +3,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />

--- a/sourcecodes/FSV.Extensions.Serialization.UnitTest/FSV.Extensions.Serialization.UnitTest.csproj
+++ b/sourcecodes/FSV.Extensions.Serialization.UnitTest/FSV.Extensions.Serialization.UnitTest.csproj
@@ -6,13 +6,13 @@
     <TargetFramework>net9.0-windows</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/sourcecodes/FSV.Extensions.Serialization/FSV.Extensions.Serialization.csproj
+++ b/sourcecodes/FSV.Extensions.Serialization/FSV.Extensions.Serialization.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Authors>G-TAC</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <Product>FolderSecurityViewer</Product>
     <TargetFramework>net9.0</TargetFramework>

--- a/sourcecodes/FSV.Extensions.Serialization/FSV.Extensions.Serialization.csproj
+++ b/sourcecodes/FSV.Extensions.Serialization/FSV.Extensions.Serialization.csproj
@@ -13,7 +13,7 @@
     <Version>2.6.0</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSV.Extensions.DependencyInjection\FSV.Extensions.DependencyInjection.csproj" />

--- a/sourcecodes/FSV.Extensions.Serialization/FSV.Extensions.Serialization.csproj
+++ b/sourcecodes/FSV.Extensions.Serialization/FSV.Extensions.Serialization.csproj
@@ -4,7 +4,7 @@
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Authors>G-TAC</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <LangVersion>latest</LangVersion>

--- a/sourcecodes/FSV.Extensions.Serialization/FSV.Extensions.Serialization.csproj
+++ b/sourcecodes/FSV.Extensions.Serialization/FSV.Extensions.Serialization.csproj
@@ -9,7 +9,7 @@
     <FileVersion>2.8.1</FileVersion>
     <LangVersion>latest</LangVersion>
     <Product>FolderSecurityViewer</Product>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Version>2.6.0</Version>
   </PropertyGroup>
   <ItemGroup>

--- a/sourcecodes/FSV.Extensions.WindowConfiguration.Test/FSV.Extensions.WindowConfiguration.Test.csproj
+++ b/sourcecodes/FSV.Extensions.WindowConfiguration.Test/FSV.Extensions.WindowConfiguration.Test.csproj
@@ -7,35 +7,35 @@
     <Product>FSV.Extensions.WindowConfiguration.Test</Product>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>3.5.0</Version>
+      <Version>4.0.2</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.5.0</Version>
+      <Version>4.0.2</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.9.0</Version>
+      <Version>2.9.3</Version>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.20.70</Version>
+      <Version>4.20.72</Version>
     </PackageReference>
     <PackageReference Include="System.IO.Abstractions">
-      <Version>21.0.26</Version>
+      <Version>22.0.16</Version>
     </PackageReference>
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers">
-      <Version>21.0.26</Version>
+      <Version>22.0.16</Version>
     </PackageReference>
     <PackageReference Include="Xunit.StaFact">
-      <Version>1.1.11</Version>
+      <Version>3.0.13</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/sourcecodes/FSV.Extensions.WindowConfiguration.Test/FSV.Extensions.WindowConfiguration.Test.csproj
+++ b/sourcecodes/FSV.Extensions.WindowConfiguration.Test/FSV.Extensions.WindowConfiguration.Test.csproj
@@ -8,19 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="MSTest.TestAdapter">
-      <Version>4.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="MSTest.TestFramework">
-      <Version>4.0.2</Version>
-    </PackageReference>
-    <PackageReference Include="xunit">
-      <Version>2.9.3</Version>
-    </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -34,9 +21,8 @@
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers">
       <Version>22.0.16</Version>
     </PackageReference>
-    <PackageReference Include="Xunit.StaFact">
-      <Version>3.0.13</Version>
-    </PackageReference>
+    <PackageReference Include="Xunit.StaFact" Version="3.0.13" />
+    <PackageReference Include="xunit.v3" Version="3.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FSV.Configuration.Abstractions\FSV.Configuration.Abstractions.csproj">

--- a/sourcecodes/FSV.Extensions.WindowConfiguration.Test/FSV.Extensions.WindowConfiguration.Test.csproj
+++ b/sourcecodes/FSV.Extensions.WindowConfiguration.Test/FSV.Extensions.WindowConfiguration.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>FSV.Extensions.WindowConfiguration.Test</AssemblyTitle>

--- a/sourcecodes/FSV.Extensions.WindowConfiguration.Test/WindowConfigurationManagerTest.cs
+++ b/sourcecodes/FSV.Extensions.WindowConfiguration.Test/WindowConfigurationManagerTest.cs
@@ -1,5 +1,5 @@
 // FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
-// Copyright (C) 2015 - 2024  Carsten Sch‰fer, Matthias Friedrich, and Ritesh Gite
+// Copyright (C) 2015 - 2024  Carsten Sch√§fer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -16,17 +16,24 @@
 
 namespace FSV.Extensions.WindowConfiguration.Test
 {
+    using Abstractions;
+
+    using Configuration.Abstractions;
+
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    using Moq;
+
+    using Serialization.Abstractions;
+
     using System.IO;
     using System.IO.Abstractions;
     using System.IO.Abstractions.TestingHelpers;
-    using Abstractions;
-    using Configuration.Abstractions;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Logging.Abstractions;
-    using Moq;
-    using Serialization.Abstractions;
+    using System.Threading.Tasks;
+
     using Xunit;
-    
+
     public class WindowConfigurationManagerTest
     {
         [Fact]
@@ -134,7 +141,7 @@ namespace FSV.Extensions.WindowConfiguration.Test
         }
 
         [Fact]
-        public void WindowConfigurationManager_SaveAsync_Test()
+        public async Task WindowConfigurationManager_SaveAsync_Test()
         {
             // Arrange
             const WindowState windowState = WindowState.Maximized;
@@ -142,7 +149,7 @@ namespace FSV.Extensions.WindowConfiguration.Test
             var settings = new Settings(expectedPosition);
 
             IMockFileDataAccessor mockFileDataAccessor = new MockFileSystem();
-            using var stream = new MockFileStream(mockFileDataAccessor, "Window.json", FileMode.OpenOrCreate, FileAccess.ReadWrite);
+            await using var stream = new MockFileStream(mockFileDataAccessor, "Window.json", FileMode.OpenOrCreate, FileAccess.ReadWrite);
 
             var serializerMock = new Mock<ISerializationWrapper>();
             serializerMock.Setup(wrapper => wrapper.SerializeAsync(stream, settings)).Verifiable();
@@ -168,7 +175,7 @@ namespace FSV.Extensions.WindowConfiguration.Test
 
             // Act
             sut.SetPosition(expectedPosition);
-            sut.SaveAsync();
+            await sut.SaveAsync();
 
             // Assert
             fileMock.Verify(file => file.Open(It.IsAny<string>(), FileMode.OpenOrCreate), Times.Once);

--- a/sourcecodes/FSV.Extensions.WindowConfiguration.Test/WindowExtensionsTest.cs
+++ b/sourcecodes/FSV.Extensions.WindowConfiguration.Test/WindowExtensionsTest.cs
@@ -1,5 +1,5 @@
 // FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
-// Copyright (C) 2015 - 2024  Carsten Sch‰fer, Matthias Friedrich, and Ritesh Gite
+// Copyright (C) 2015 - 2024  Carsten Sch√§fer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -16,9 +16,12 @@
 
 namespace FSV.Extensions.WindowConfiguration.Test
 {
-    using System.Windows;
     using Abstractions;
+
+    using System.Windows;
+
     using Xunit;
+
     using WindowState = System.Windows.WindowState;
 
     /// <summary>

--- a/sourcecodes/FSV.Extensions.WindowConfiguration/FSV.Extensions.WindowConfiguration.csproj
+++ b/sourcecodes/FSV.Extensions.WindowConfiguration/FSV.Extensions.WindowConfiguration.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyTitle>FSV.Extensions.Configuration</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>
   <ItemGroup>

--- a/sourcecodes/FSV.Extensions.WindowConfiguration/FSV.Extensions.WindowConfiguration.csproj
+++ b/sourcecodes/FSV.Extensions.WindowConfiguration/FSV.Extensions.WindowConfiguration.csproj
@@ -5,7 +5,7 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <PropertyGroup>

--- a/sourcecodes/FSV.Extensions.WindowConfiguration/FSV.Extensions.WindowConfiguration.csproj
+++ b/sourcecodes/FSV.Extensions.WindowConfiguration/FSV.Extensions.WindowConfiguration.csproj
@@ -12,7 +12,7 @@
     <AssemblyTitle>FSV.Extensions.Configuration</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <Product>FolderSecurityViewer</Product>

--- a/sourcecodes/FSV.Extensions.WindowConfiguration/FSV.Extensions.WindowConfiguration.csproj
+++ b/sourcecodes/FSV.Extensions.WindowConfiguration/FSV.Extensions.WindowConfiguration.csproj
@@ -27,10 +27,10 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.IO.Abstractions">
-      <Version>21.0.26</Version>
+      <Version>22.0.16</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.FileSystem.Interop.Abstractions/FSV.FileSystem.Interop.Abstractions.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop.Abstractions/FSV.FileSystem.Interop.Abstractions.csproj
@@ -10,7 +10,7 @@
     <LangVersion>latest</LangVersion>
     <PackageVersion>2.4.4</PackageVersion>
     <Product>FolderSecurityViewer</Product>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Title>FSV.FileSystem.Interop.Abstractions</Title>
     <Version>2.4.4.0</Version>
   </PropertyGroup>

--- a/sourcecodes/FSV.FileSystem.Interop.Abstractions/FSV.FileSystem.Interop.Abstractions.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop.Abstractions/FSV.FileSystem.Interop.Abstractions.csproj
@@ -4,7 +4,7 @@
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Authors>G-TAC</Authors>
     <Company>G-TAC</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <LangVersion>latest</LangVersion>

--- a/sourcecodes/FSV.FileSystem.Interop.Abstractions/FSV.FileSystem.Interop.Abstractions.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop.Abstractions/FSV.FileSystem.Interop.Abstractions.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Authors>G-TAC</Authors>
     <Company>G-TAC</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <PackageVersion>2.4.4</PackageVersion>
     <Product>FolderSecurityViewer</Product>

--- a/sourcecodes/FSV.FileSystem.Interop.Core.Abstractions/FSV.FileSystem.Interop.Core.Abstractions.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop.Core.Abstractions/FSV.FileSystem.Interop.Core.Abstractions.csproj
@@ -4,7 +4,7 @@
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Authors>Matthias Friedrich</Authors>
     <Company>G-TAC</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <LangVersion>latest</LangVersion>

--- a/sourcecodes/FSV.FileSystem.Interop.Core.Abstractions/FSV.FileSystem.Interop.Core.Abstractions.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop.Core.Abstractions/FSV.FileSystem.Interop.Core.Abstractions.csproj
@@ -10,7 +10,7 @@
     <LangVersion>latest</LangVersion>
     <PackageVersion>2.4.4</PackageVersion>
     <Product>FolderSecurityViewer</Product>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Title>FSV.FileSystem.Interop.Core.Abstractions</Title>
     <Version>2.4.4.0</Version>
   </PropertyGroup>

--- a/sourcecodes/FSV.FileSystem.Interop.Core.Abstractions/FSV.FileSystem.Interop.Core.Abstractions.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop.Core.Abstractions/FSV.FileSystem.Interop.Core.Abstractions.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Authors>Matthias Friedrich</Authors>
     <Company>G-TAC</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <PackageVersion>2.4.4</PackageVersion>
     <Product>FolderSecurityViewer</Product>

--- a/sourcecodes/FSV.FileSystem.Interop.Core/FSV.FileSystem.Interop.Core.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop.Core/FSV.FileSystem.Interop.Core.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Authors>Matthias Friedrich</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <PackageVersion>2.4.4</PackageVersion>
     <Product>FolderSecurityViewer</Product>

--- a/sourcecodes/FSV.FileSystem.Interop.Core/FSV.FileSystem.Interop.Core.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop.Core/FSV.FileSystem.Interop.Core.csproj
@@ -4,7 +4,7 @@
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Authors>Matthias Friedrich</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <LangVersion>latest</LangVersion>

--- a/sourcecodes/FSV.FileSystem.Interop.Core/FSV.FileSystem.Interop.Core.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop.Core/FSV.FileSystem.Interop.Core.csproj
@@ -10,7 +10,7 @@
     <LangVersion>latest</LangVersion>
     <PackageVersion>2.4.4</PackageVersion>
     <Product>FolderSecurityViewer</Product>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Title>FSV.FileSystem.Interop.Core</Title>
     <Version>2.6.0.0</Version>
   </PropertyGroup>

--- a/sourcecodes/FSV.FileSystem.Interop.UnitTest/DirectorySizeTest.cs
+++ b/sourcecodes/FSV.FileSystem.Interop.UnitTest/DirectorySizeTest.cs
@@ -1,5 +1,5 @@
 // FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
-// Copyright (C) 2015 - 2024  Carsten Schäfer, Matthias Friedrich, and Ritesh Gite
+// Copyright (C) 2015 - 2024  Carsten SchÃ¤fer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -43,9 +43,8 @@ namespace FSV.FileSystem.Interop.UnitTest
             FolderSizeInfo actual = sut.AggregateSizeInfo(directoryPath, includeSubtrees, includeHiddenFolders);
 
             // Assert
-            Assert.IsNotNull(actual);
-            Assert.IsTrue(actual.Size > 0);
-            Assert.IsTrue(actual.FileCount > 0);
+            Assert.IsGreaterThan(0, actual.Size);
+            Assert.IsGreaterThan(0, actual.FileCount);
         }
     }
 }

--- a/sourcecodes/FSV.FileSystem.Interop.UnitTest/FSV.FileSystem.Interop.UnitTest.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop.UnitTest/FSV.FileSystem.Interop.UnitTest.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <AssemblyTitle>FSV.FileSystem.Interop.UnitTest</AssemblyTitle>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <FileVersion>1.0.0.0</FileVersion>
     <Product>FSV.FileSystem.Interop.UnitTest</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.FileSystem.Interop.UnitTest/FSV.FileSystem.Interop.UnitTest.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop.UnitTest/FSV.FileSystem.Interop.UnitTest.csproj
@@ -22,17 +22,17 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>17.10.0</Version>
+      <Version>18.0.1</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.20.70</Version>
+      <Version>4.20.72</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>3.5.0</Version>
+      <Version>4.0.2</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.5.0</Version>
+      <Version>4.0.2</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.FileSystem.Interop.UnitTest/FSV.FileSystem.Interop.UnitTest.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop.UnitTest/FSV.FileSystem.Interop.UnitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>latest</LangVersion>

--- a/sourcecodes/FSV.FileSystem.Interop.UnitTest/FindFileEnumeratorTest.cs
+++ b/sourcecodes/FSV.FileSystem.Interop.UnitTest/FindFileEnumeratorTest.cs
@@ -1,4 +1,4 @@
-﻿// FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
+// FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
 // Copyright (C) 2015 - 2024  Carsten Schäfer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
@@ -37,7 +37,7 @@ namespace FSV.FileSystem.Interop.UnitTest
             using var sut = new FindFileEnumerator(kernel32, kernel32FindFile, path);
 
             // Assert
-            Assert.AreEqual(sut.Current, default);
+            Assert.IsNull(sut.Current);
         }
 
         [TestMethod]
@@ -57,7 +57,8 @@ namespace FSV.FileSystem.Interop.UnitTest
 
             // Assert
             Assert.IsTrue(actual);
-
+            Assert.IsNotNull(sut.Current);
+            
             Win32FindData current = sut.Current.GetWin32FindData(false);
             Assert.AreNotEqual(default, current);
             Assert.AreEqual(expected, current.cFileName);
@@ -77,11 +78,11 @@ namespace FSV.FileSystem.Interop.UnitTest
             sut.MoveNext();
 
             // Act
-            bool actual = sut.MoveNext();
+            sut.MoveNext();
             sut.Reset();
 
             // Assert
-            Assert.AreEqual(sut.Current, default);
+            Assert.IsNull(sut.Current);
         }
     }
 }

--- a/sourcecodes/FSV.FileSystem.Interop.UnitTest/FindFileEnumeratorTest.cs
+++ b/sourcecodes/FSV.FileSystem.Interop.UnitTest/FindFileEnumeratorTest.cs
@@ -45,7 +45,7 @@ namespace FSV.FileSystem.Interop.UnitTest
         {
             // Arrange
             string path = Environment.CurrentDirectory;
-            const string expected = "net8.0-windows";
+            const string expected = "net9.0-windows";
 
             var kernel32 = new Kernel32Wrapper();
             var kernel32FindFile = new Kernel32FindFileWrapper();

--- a/sourcecodes/FSV.FileSystem.Interop/FSV.FileSystem.Interop.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop/FSV.FileSystem.Interop.csproj
@@ -33,7 +33,7 @@
     <ProjectReference Include="..\FSV.FileSystem.Interop.Core\FSV.FileSystem.Interop.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="System.Security.AccessControl" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.FileSystem.Interop/FSV.FileSystem.Interop.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop/FSV.FileSystem.Interop.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/sourcecodes/FSV.FileSystem.Interop/FSV.FileSystem.Interop.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop/FSV.FileSystem.Interop.csproj
@@ -20,7 +20,7 @@
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Authors>Matthias Friedrich</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.FileSystem.Interop/FSV.FileSystem.Interop.csproj
+++ b/sourcecodes/FSV.FileSystem.Interop/FSV.FileSystem.Interop.csproj
@@ -17,12 +17,12 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.FileSystem.Interop</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Authors>Matthias Friedrich</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.FolderTree/FSV.FolderTree.csproj
+++ b/sourcecodes/FSV.FolderTree/FSV.FolderTree.csproj
@@ -5,7 +5,7 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <OutputType>Library</OutputType>
     <RestorePackages>true</RestorePackages>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/sourcecodes/FSV.FolderTree/FSV.FolderTree.csproj
+++ b/sourcecodes/FSV.FolderTree/FSV.FolderTree.csproj
@@ -64,7 +64,7 @@
     <ProjectReference Include="..\FSV.FileSystem.Interop.Core\FSV.FileSystem.Interop.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.HtmlExporter/FSV.HtmlExporter.csproj
+++ b/sourcecodes/FSV.HtmlExporter/FSV.HtmlExporter.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="HtmlTags">
       <Version>9.0.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.SystemWebAdapters" Version="1.4.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SystemWebAdapters" Version="2.1.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.HtmlExporter/FSV.HtmlExporter.csproj
+++ b/sourcecodes/FSV.HtmlExporter/FSV.HtmlExporter.csproj
@@ -12,11 +12,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.HtmlExporter</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>

--- a/sourcecodes/FSV.HtmlExporter/FSV.HtmlExporter.csproj
+++ b/sourcecodes/FSV.HtmlExporter/FSV.HtmlExporter.csproj
@@ -14,7 +14,7 @@
     <AssemblyTitle>FSV.HtmlExporter</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/sourcecodes/FSV.HtmlExporter/FSV.HtmlExporter.csproj
+++ b/sourcecodes/FSV.HtmlExporter/FSV.HtmlExporter.csproj
@@ -20,7 +20,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="Resources\MainResource.Designer.cs">

--- a/sourcecodes/FSV.Models/FSV.Models.csproj
+++ b/sourcecodes/FSV.Models/FSV.Models.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/sourcecodes/FSV.Models/FSV.Models.csproj
+++ b/sourcecodes/FSV.Models/FSV.Models.csproj
@@ -16,7 +16,7 @@
     <AssemblyTitle>FSV.Models</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.Models/FSV.Models.csproj
+++ b/sourcecodes/FSV.Models/FSV.Models.csproj
@@ -26,6 +26,6 @@
     <ProjectReference Include="..\FSV.Configuration\FSV.Configuration.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.Models/FSV.Models.csproj
+++ b/sourcecodes/FSV.Models/FSV.Models.csproj
@@ -14,11 +14,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.Models</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Resources/FSV.Resources.csproj
+++ b/sourcecodes/FSV.Resources/FSV.Resources.csproj
@@ -16,7 +16,7 @@
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Product>FolderSecurityViewer</Product>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.Resources/FSV.Resources.csproj
+++ b/sourcecodes/FSV.Resources/FSV.Resources.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/sourcecodes/FSV.Resources/FSV.Resources.csproj
+++ b/sourcecodes/FSV.Resources/FSV.Resources.csproj
@@ -17,8 +17,8 @@
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Product>FolderSecurityViewer</Product>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
-    <FileVersion>2.8.1</FileVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <AnalysisLevel>none</AnalysisLevel>
   </PropertyGroup>

--- a/sourcecodes/FSV.Security/FSV.Security.csproj
+++ b/sourcecodes/FSV.Security/FSV.Security.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/sourcecodes/FSV.Security/FSV.Security.csproj
+++ b/sourcecodes/FSV.Security/FSV.Security.csproj
@@ -10,11 +10,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.Security</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.Security/FSV.Security.csproj
+++ b/sourcecodes/FSV.Security/FSV.Security.csproj
@@ -12,7 +12,7 @@
     <AssemblyTitle>FSV.Security</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/sourcecodes/FSV.Security/FSV.Security.csproj
+++ b/sourcecodes/FSV.Security/FSV.Security.csproj
@@ -22,7 +22,7 @@
     <ProjectReference Include="..\FSV.Extensions.DependencyInjection\FSV.Extensions.DependencyInjection.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="System.Security.Permissions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="System.Security.Permissions" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.ShareServices.UnitTest/FSV.ShareServices.UnitTest.csproj
+++ b/sourcecodes/FSV.ShareServices.UnitTest/FSV.ShareServices.UnitTest.csproj
@@ -9,7 +9,7 @@
     <LangVersion>default</LangVersion>
     <OutputType>Library</OutputType>
     <Product>FSV.ShareServices.UnitTest</Product>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/sourcecodes/FSV.ShareServices.UnitTest/FSV.ShareServices.UnitTest.csproj
+++ b/sourcecodes/FSV.ShareServices.UnitTest/FSV.ShareServices.UnitTest.csproj
@@ -13,16 +13,16 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>17.10.0</Version>
+      <Version>18.0.1</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.20.70</Version>
+      <Version>4.20.72</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>3.5.0</Version>
+      <Version>4.0.2</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.5.0</Version>
+      <Version>4.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/sourcecodes/FSV.ShareServices.UnitTest/FSV.ShareServices.UnitTest.csproj
+++ b/sourcecodes/FSV.ShareServices.UnitTest/FSV.ShareServices.UnitTest.csproj
@@ -3,7 +3,7 @@
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.ShareServices.UnitTest</AssemblyTitle>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <FileVersion>1.0.0.0</FileVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>default</LangVersion>

--- a/sourcecodes/FSV.ShareServices.UnitTest/ShareServersManagerTest.cs
+++ b/sourcecodes/FSV.ShareServices.UnitTest/ShareServersManagerTest.cs
@@ -1,5 +1,5 @@
 // FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
-// Copyright (C) 2015 - 2024  Carsten Sch‰fer, Matthias Friedrich, and Ritesh Gite
+// Copyright (C) 2015 - 2024  Carsten Sch√§fer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -38,7 +38,7 @@ namespace FSV.ShareServices.UnitTest
             await manager.GetServerListAsync();
             bool result = manager.ServerExists("MyServer");
 
-            Assert.AreEqual(false, result);
+            Assert.IsFalse(result);
         }
 
         [TestMethod]
@@ -51,7 +51,7 @@ namespace FSV.ShareServices.UnitTest
             await manager.GetServerListAsync();
             bool result = manager.ServerExists("WinServers");
 
-            Assert.AreEqual(true, result);
+            Assert.IsTrue(result);
         }
 
         [TestMethod]
@@ -67,7 +67,7 @@ namespace FSV.ShareServices.UnitTest
 
             Assert.AreEqual(ServerState.NotScanned, serverItem.State);
             Assert.AreEqual(serverName, serverItem.Name);
-            Assert.AreEqual(0, serverItem.Shares.Count);
+            Assert.IsEmpty(serverItem.Shares);
         }
 
         [TestMethod]
@@ -85,7 +85,7 @@ namespace FSV.ShareServices.UnitTest
             ServerItem serverItem = manager.CreateServer(serverName);
             ShareItem shareItem = manager.CreateShare(serverItem, shareName, sharePath);
 
-            Assert.AreEqual(1, serverItem.Shares.Count);
+            Assert.HasCount(1, serverItem.Shares);
             Assert.AreEqual(shareName, shareItem.Name);
             Assert.AreEqual(sharePath, shareItem.Path);
         }

--- a/sourcecodes/FSV.ShareServices/FSV.ShareServices.csproj
+++ b/sourcecodes/FSV.ShareServices/FSV.ShareServices.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Authors>G-TAC</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>

--- a/sourcecodes/FSV.ShareServices/FSV.ShareServices.csproj
+++ b/sourcecodes/FSV.ShareServices/FSV.ShareServices.csproj
@@ -4,7 +4,7 @@
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Authors>G-TAC</Authors>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <LangVersion>latest</LangVersion>

--- a/sourcecodes/FSV.ShareServices/FSV.ShareServices.csproj
+++ b/sourcecodes/FSV.ShareServices/FSV.ShareServices.csproj
@@ -18,9 +18,9 @@
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/sourcecodes/FSV.ShareServices/FSV.ShareServices.csproj
+++ b/sourcecodes/FSV.ShareServices/FSV.ShareServices.csproj
@@ -10,7 +10,7 @@
     <LangVersion>latest</LangVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <Version>2.4.1</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/sourcecodes/FSV.Templates/FSV.Templates.csproj
+++ b/sourcecodes/FSV.Templates/FSV.Templates.csproj
@@ -16,7 +16,7 @@
     <AssemblyTitle>FSV.Templates</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.Templates/FSV.Templates.csproj
+++ b/sourcecodes/FSV.Templates/FSV.Templates.csproj
@@ -14,11 +14,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.Templates</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.ViewModel.UnitTest/AdBrowserViewModelTest.cs
+++ b/sourcecodes/FSV.ViewModel.UnitTest/AdBrowserViewModelTest.cs
@@ -1,4 +1,4 @@
-﻿// FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
+// FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
 // Copyright (C) 2015 - 2024  Carsten Schäfer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
@@ -26,13 +26,14 @@ namespace FSV.ViewModel.UnitTest
     using AdServices.EnumOU;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
     using Prism.Events;
-    using Xunit;
 
+    [TestClass]
     public class AdBrowserViewModelTest
     {
-        [Fact]
+        [TestMethod]
         public async Task AdBrowserViewModel_SearchPrincipals_no_result_test()
         {
             const string principalName = "user_1202";
@@ -49,13 +50,13 @@ namespace FSV.ViewModel.UnitTest
             await sut.SearchPrincipalCommand.ExecuteAsync(null);
 
             // Assert
-            Assert.Equal(principalName, sut.PrincipalName);
-            Assert.Empty(sut.UserPrincipals);
-            Assert.False(sut.ShowUserList);
-            Assert.False(sut.CanReport);
+            Assert.AreEqual(principalName, sut.PrincipalName);
+            Assert.IsEmpty(sut.UserPrincipals);
+            Assert.IsFalse(sut.ShowUserList);
+            Assert.IsFalse(sut.CanReport);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task AdBrowserViewModel_SearchPrincipals_single_result_test()
         {
             const string principalName = "user_1202";
@@ -72,24 +73,23 @@ namespace FSV.ViewModel.UnitTest
             await sut.SearchPrincipalCommand.ExecuteAsync(null);
 
             // Assert
-            Assert.Equal(principalName, sut.PrincipalName);
-            Assert.False(sut.ShowUserList);
-            Assert.True(sut.CanReport);
+            Assert.AreEqual(principalName, sut.PrincipalName);
+            Assert.IsFalse(sut.ShowUserList);
+            Assert.IsTrue(sut.CanReport);
 
-            Assert.Collection(sut.UserPrincipals,
-                item =>
+            foreach (AdTreeViewModel item in sut.UserPrincipals)
+            {
+                if (item is null)
                 {
-                    if (item is null)
-                    {
-                        throw new ArgumentNullException(nameof(item));
-                    }
+                    throw new ArgumentNullException(nameof(item));
+                }
 
-                    Assert.Equal(principalName, item.SamAccountName);
-                    Assert.Equal(TreeViewNodeType.User, item.Type);
-                });
+                Assert.AreEqual(principalName, item.SamAccountName);
+                Assert.AreEqual(TreeViewNodeType.User, item.Type);
+            }
         }
 
-        [Fact]
+        [TestMethod]
         public async Task AdBrowserViewModel_SearchPrincipals_collection_result_test()
         {
             const string principalName = "*12*";
@@ -106,31 +106,30 @@ namespace FSV.ViewModel.UnitTest
             await sut.SearchPrincipalCommand.ExecuteAsync(null);
 
             // Assert
-            Assert.True(sut.ShowUserList);
-            Assert.Collection(sut.UserPrincipals,
-                item =>
+            Assert.IsTrue(sut.ShowUserList);
+            foreach (AdTreeViewModel item in sut.UserPrincipals)
+            {
+                if (item is null)
                 {
-                    if (item is null)
-                    {
-                        throw new ArgumentNullException(nameof(item));
-                    }
+                    throw new ArgumentNullException(nameof(item));
+                }
 
-                    Assert.Equal("user_display", item.DistinguishedName);
-                    Assert.Equal(TreeViewNodeType.User, item.Type);
-                },
-                item =>
+                switch (item.Type)
                 {
-                    if (item is null)
-                    {
-                        throw new ArgumentNullException(nameof(item));
-                    }
-
-                    Assert.Equal("group_display", item.DistinguishedName);
-                    Assert.Equal(TreeViewNodeType.Group, item.Type);
-                });
+                    case TreeViewNodeType.User:
+                        Assert.AreEqual("user_display", item.DistinguishedName);
+                        break;
+                    case TreeViewNodeType.Group:
+                        Assert.AreEqual("group_display", item.DistinguishedName);
+                        break;
+                    default:
+                        Assert.Fail("unexpected item type");
+                        break;
+                }
+            }
         }
 
-        [Fact]
+        [TestMethod]
         public async Task AdBrowserViewModel_selection_test()
         {
             const string principalName = "user1203";
@@ -154,9 +153,13 @@ namespace FSV.ViewModel.UnitTest
             IPrincipalViewModel selectedItem = GetSelectedPrincipal(sut.Principals);
 
             // Assert
-            Assert.Collection(sut.Principals, item => Assert.Equal("the_domain.test", item.DisplayName));
-            Assert.NotNull(selectedItem);
-            Assert.Equal(principalName, selectedItem.SamAccountName);
+            foreach (IPrincipalViewModel item in sut.Principals)
+            {
+                Assert.AreEqual("the_domain.test", item.DisplayName);
+            }
+
+            Assert.IsNotNull(selectedItem);
+            Assert.AreEqual(principalName, selectedItem.SamAccountName);
         }
 
         private IServiceProvider ConfigureAllServices(Mock<IAdBrowserService> mockAdBrowserService)

--- a/sourcecodes/FSV.ViewModel.UnitTest/DomainViewModelTest.cs
+++ b/sourcecodes/FSV.ViewModel.UnitTest/DomainViewModelTest.cs
@@ -1,4 +1,4 @@
-﻿// FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
+// FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
 // Copyright (C) 2015 - 2024  Carsten Schäfer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
@@ -17,6 +17,7 @@
 namespace FSV.ViewModel.UnitTest
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
@@ -25,12 +26,13 @@ namespace FSV.ViewModel.UnitTest
     using AdServices.EnumOU;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
-    using Xunit;
 
+    [TestClass]
     public class DomainViewModelTest
     {
-        [Fact]
+        [TestMethod]
         public async Task DomainViewModel_Initialize_for_computers_test()
         {
             const string domainName = "test.local";
@@ -45,18 +47,18 @@ namespace FSV.ViewModel.UnitTest
             await sut.InitializeAsync();
 
             // Assert
-            Assert.NotNull(sut.Items);
-            Assert.Null(sut.Parent);
+            Assert.IsNotNull(sut.Items);
+            Assert.IsNull(sut.Parent);
 
-            Assert.All(sut.Items,
-                item =>
-                {
-                    Assert.IsType<ComputerPrincipalViewModel>(item);
-                    Assert.NotNull(item.Parent);
-                });
+            ICollection list = sut.Items.ToList();
+            CollectionAssert.AllItemsAreInstancesOfType(list, typeof(ComputerPrincipalViewModel));
+            foreach (IPrincipalViewModel item in sut.Items)
+            {
+                Assert.IsNotNull(item.Parent);
+            }
         }
 
-        [Fact]
+        [TestMethod]
         public async Task DomainViewModel_Initialize_for_principals_test()
         {
             const string domainName = "test.local";
@@ -71,15 +73,14 @@ namespace FSV.ViewModel.UnitTest
             await sut.InitializeAsync();
 
             // Assert
-            Assert.NotNull(sut.Items);
-            Assert.Null(sut.Parent);
+            Assert.IsNotNull(sut.Items);
+            Assert.IsNull(sut.Parent);
 
-            Assert.All(sut.Items,
-                item =>
-                {
-                    Assert.IsType<PrincipalViewModel>(item);
-                    Assert.NotNull(item.Parent);
-                });
+            CollectionAssert.AllItemsAreInstancesOfType(sut.Items.ToList(), typeof(PrincipalViewModel));
+            foreach (IPrincipalViewModel item in sut.Items)
+            {
+                Assert.IsNotNull(item.Parent);
+            }
         }
 
         private IServiceProvider ConfigureAllServices(IAdBrowserService adBrowserService)

--- a/sourcecodes/FSV.ViewModel.UnitTest/FSV.ViewModel.UnitTest.csproj
+++ b/sourcecodes/FSV.ViewModel.UnitTest/FSV.ViewModel.UnitTest.csproj
@@ -29,12 +29,6 @@
     <PackageReference Include="MSTest.TestFramework">
       <Version>4.0.2</Version>
     </PackageReference>
-    <PackageReference Include="xunit">
-      <Version>2.9.3</Version>
-    </PackageReference>
-    <PackageReference Include="Xunit.StaFact">
-      <Version>3.0.13</Version>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FolderSecurityViewer\FolderSecurityViewer.csproj" />

--- a/sourcecodes/FSV.ViewModel.UnitTest/FSV.ViewModel.UnitTest.csproj
+++ b/sourcecodes/FSV.ViewModel.UnitTest/FSV.ViewModel.UnitTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>latest</LangVersion>

--- a/sourcecodes/FSV.ViewModel.UnitTest/FSV.ViewModel.UnitTest.csproj
+++ b/sourcecodes/FSV.ViewModel.UnitTest/FSV.ViewModel.UnitTest.csproj
@@ -18,22 +18,22 @@
     <EmbeddedResource Include="Json\Folders.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="5.1.1" />
+    <PackageReference Include="Castle.Core" Version="5.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>17.10.0</Version>
+      <Version>18.0.1</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.20.70</Version>
+      <Version>4.20.72</Version>
     </PackageReference>
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
     <PackageReference Include="MSTest.TestFramework">
-      <Version>3.5.0</Version>
+      <Version>4.0.2</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.9.0</Version>
+      <Version>2.9.3</Version>
     </PackageReference>
     <PackageReference Include="Xunit.StaFact">
-      <Version>1.1.11</Version>
+      <Version>3.0.13</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/sourcecodes/FSV.ViewModel.UnitTest/FSV.ViewModel.UnitTest.csproj
+++ b/sourcecodes/FSV.ViewModel.UnitTest/FSV.ViewModel.UnitTest.csproj
@@ -9,7 +9,7 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <AssemblyTitle>FSV.ViewModel.UnitTest</AssemblyTitle>
     <Product>FSV.ViewModel.UnitTest</Product>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
     <AnalysisLevel>none</AnalysisLevel>

--- a/sourcecodes/FSV.ViewModel.UnitTest/FolderTreeItemSelectorTest.cs
+++ b/sourcecodes/FSV.ViewModel.UnitTest/FolderTreeItemSelectorTest.cs
@@ -1,5 +1,5 @@
 // FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
-// Copyright (C) 2015 - 2024  Carsten Sch‰fer, Matthias Friedrich, and Ritesh Gite
+// Copyright (C) 2015 - 2024  Carsten Sch√§fer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -25,12 +25,13 @@ namespace FSV.ViewModel.UnitTest
     using Abstractions;
     using Home;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
-    using Xunit;
 
+    [TestClass]
     public class FolderTreeItemSelectorTest
     {
-        [Fact]
+        [TestMethod]
         public async Task FolderTreeItemSelector_GetNextAsync_returns_expected_folder_test()
         {
             // Arrange
@@ -56,10 +57,15 @@ namespace FSV.ViewModel.UnitTest
                 actualFolders.Add(resultFolder?.Path);
             }
 
-            Assert.Equal(expectedFolders, actualFolders, StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < expectedFolders.Length && i < actualFolders.Count; i++)
+            {
+                string expectedFolder = expectedFolders[i];
+                string actualFolder = actualFolders[i];
+                Assert.AreEqual(0, StringComparer.OrdinalIgnoreCase.Compare(expectedFolder, actualFolder));
+            }
         }
 
-        [Fact]
+        [TestMethod]
         public async Task FolderTreeItemSelector_GetNextAsync_null_is_returned_from_folderFactory_test()
         {
             // Arrange
@@ -71,10 +77,10 @@ namespace FSV.ViewModel.UnitTest
             // Act
             FolderTreeItemViewModel result = await sut.GetNextAsync("s", selectedFolder);
 
-            Assert.Equal(selectedFolder, result);
+            Assert.AreEqual(selectedFolder, result);
         }
 
-        [Fact]
+        [TestMethod]
         public async Task FolderTreeItemSelector_GetNextAsync_null_is_returned_when_key_not_found_test()
         {
             // Arrange
@@ -86,7 +92,7 @@ namespace FSV.ViewModel.UnitTest
             // Act
             FolderTreeItemViewModel result = await sut.GetNextAsync("master", selectedFolder);
 
-            Assert.Null(result);
+            Assert.IsNull(result);
         }
 
         private IFolderTreeItemSelector GetFolderTreeItemSelector(IEnumerable<FolderTreeItemViewModel> folders)

--- a/sourcecodes/FSV.ViewModel.UnitTest/FolderTreeItemViewModelTest.cs
+++ b/sourcecodes/FSV.ViewModel.UnitTest/FolderTreeItemViewModelTest.cs
@@ -1,4 +1,4 @@
-﻿// FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
+// FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
 // Copyright (C) 2015 - 2024  Carsten Schäfer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
@@ -20,15 +20,16 @@ namespace FSV.ViewModel.UnitTest
     using FolderTree;
     using Home;
     using JetBrains.Annotations;
-    using Xunit;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+    [TestClass]
     public class FolderTreeItemViewModelTest
     {
-        [Fact]
+        [TestMethod]
         public void FolderTreeItemViewModel_null_equality_test()
         {
             // Arrange
-            FolderModel model = this.GetFolerModel("Folder", @"path\to\some\folder");
+            FolderModel model = this.GetFolderModel("Folder", @"path\to\some\folder");
 
             var sut = new FolderTreeItemViewModel(model);
 
@@ -36,14 +37,14 @@ namespace FSV.ViewModel.UnitTest
             bool result = sut.Equals(null);
 
             // Assert
-            Assert.False(result);
+            Assert.IsFalse(result);
         }
 
-        [Fact]
+        [TestMethod]
         public void FolderTreeItemViewModel_same_reference_equality_test()
         {
             // Arrange
-            FolderModel model = this.GetFolerModel("Folder", @"path\to\some\folder");
+            FolderModel model = this.GetFolderModel("Folder", @"path\to\some\folder");
 
             var sut = new FolderTreeItemViewModel(model);
             FolderTreeItemViewModel reference = sut;
@@ -52,15 +53,15 @@ namespace FSV.ViewModel.UnitTest
             bool result = sut.Equals(reference);
 
             // Assert
-            Assert.True(result);
+            Assert.IsTrue(result);
         }
 
-        [Fact]
+        [TestMethod]
         public void FolderTreeItemViewModel_path_equality_test()
         {
             // Arrange
-            FolderModel modelOne = this.GetFolerModel("Folder", @"path\to\some\folder");
-            FolderModel modelTwo = this.GetFolerModel("Folder", @"path\to\some\folder");
+            FolderModel modelOne = this.GetFolderModel("Folder", @"path\to\some\folder");
+            FolderModel modelTwo = this.GetFolderModel("Folder", @"path\to\some\folder");
 
             var sut = new FolderTreeItemViewModel(modelOne);
             var other = new FolderTreeItemViewModel(modelTwo);
@@ -69,10 +70,10 @@ namespace FSV.ViewModel.UnitTest
             bool result = sut.Equals(other);
 
             // Assert
-            Assert.True(result);
+            Assert.IsTrue(result);
         }
 
-        private FolderModel GetFolerModel([NotNull] string name, [NotNull] string path)
+        private FolderModel GetFolderModel([NotNull] string name, [NotNull] string path)
         {
             if (string.IsNullOrWhiteSpace(name))
             {

--- a/sourcecodes/FSV.ViewModel.UnitTest/GroupMembersViewModelTest.cs
+++ b/sourcecodes/FSV.ViewModel.UnitTest/GroupMembersViewModelTest.cs
@@ -1,5 +1,5 @@
 // FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
-// Copyright (C) 2015 - 2024  Carsten Sch‰fer, Matthias Friedrich, and Ritesh Gite
+// Copyright (C) 2015 - 2024  Carsten Sch√§fer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -45,12 +45,12 @@ namespace FSV.ViewModel.UnitTest
 
             await sut.InitializeAsync();
 
-            Assert.AreEqual(sut.GroupMembers.Count, 2);
-            Assert.AreEqual(sut.GroupMembers.First().AccountName, "User One");
-            Assert.AreEqual(sut.GroupMembers.First().IsGroup, false);
+            Assert.HasCount(2, sut.GroupMembers);
+            Assert.AreEqual("User One", sut.GroupMembers.First().AccountName);
+            Assert.IsFalse(sut.GroupMembers.First().IsGroup);
 
-            Assert.AreEqual(sut.GroupMembers.Last().AccountName, "Group Two");
-            Assert.AreEqual(sut.GroupMembers.Last().IsGroup, true);
+            Assert.AreEqual("Group Two", sut.GroupMembers.Last().AccountName);
+            Assert.IsTrue(sut.GroupMembers.Last().IsGroup);
         }
 
         [TestMethod]
@@ -68,7 +68,7 @@ namespace FSV.ViewModel.UnitTest
             DataTable exportTable = sut.GetGroupMembersDataTable(vm);
 
             Assert.IsNotNull(exportTable);
-            Assert.AreEqual(vm.GroupMembers.Count, exportTable.Rows.Count);
+            Assert.HasCount(vm.GroupMembers.Count, exportTable.Rows);
         }
 
         private IServiceProvider ConfigureAllServices(ServiceCollection services)

--- a/sourcecodes/FSV.ViewModel.UnitTest/GroupPermissionsViewModelTest.cs
+++ b/sourcecodes/FSV.ViewModel.UnitTest/GroupPermissionsViewModelTest.cs
@@ -1,4 +1,4 @@
-﻿// FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
+// FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
 // Copyright (C) 2015 - 2024  Carsten Schäfer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
@@ -49,7 +49,7 @@ namespace FSV.ViewModel.UnitTest
             // Assert
             Assert.AreSame(permissions, sut.AllPermissions);
             Assert.IsNotNull(sut.PagedPermissions);
-            Assert.AreEqual(20, sut.PagedPermissions.Rows.Count);
+            Assert.HasCount(20, sut.PagedPermissions.Rows);
         }
 
         private static DataTable GetMockDataTable()
@@ -98,7 +98,7 @@ namespace FSV.ViewModel.UnitTest
 
             var bytes = new byte[stream.Length];
 
-            stream.Read(bytes, 0, bytes.Length);
+            stream.ReadExactly(bytes, 0, bytes.Length);
             stream.Close();
 
             var memoryStream = new MemoryStream();

--- a/sourcecodes/FSV.ViewModel.UnitTest/PermissionsViewModelTest.cs
+++ b/sourcecodes/FSV.ViewModel.UnitTest/PermissionsViewModelTest.cs
@@ -1,5 +1,5 @@
 // FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
-// Copyright (C) 2015 - 2024  Carsten Sch‰fer, Matthias Friedrich, and Ritesh Gite
+// Copyright (C) 2015 - 2024  Carsten Sch√§fer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -96,7 +96,7 @@ namespace FSV.ViewModel.UnitTest
             DataTable result = sut.GetPermissionsSortTable(vm);
 
             Assert.AreEqual(vm.AllPermissions.TableName, result.TableName);
-            Assert.AreEqual(vm.AllPermissions.Rows.Count, result.Rows.Count);
+            Assert.HasCount(vm.AllPermissions.Rows.Count, result.Rows);
         }
 
         private static PermissionsViewModel CreatePermissionsViewModel()

--- a/sourcecodes/FSV.ViewModel.UnitTest/PrincipalMembershipViewModelTest.cs
+++ b/sourcecodes/FSV.ViewModel.UnitTest/PrincipalMembershipViewModelTest.cs
@@ -1,5 +1,5 @@
 // FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
-// Copyright (C) 2015 - 2024  Carsten Sch‰fer, Matthias Friedrich, and Ritesh Gite
+// Copyright (C) 2015 - 2024  Carsten Sch√§fer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -45,9 +45,9 @@ namespace FSV.ViewModel.UnitTest
 
             await sut.InitializeAsync();
 
-            Assert.AreEqual(sut.Groups.Count, 2);
-            Assert.AreEqual(sut.Groups.First().AccountName, "Finance");
-            Assert.AreEqual(sut.Groups.First().IsGroup, true);
+            Assert.HasCount(2, sut.Groups);
+            Assert.AreEqual("Finance", sut.Groups.First().AccountName);
+            Assert.IsTrue(sut.Groups.First().IsGroup);
         }
 
         [TestMethod]
@@ -65,7 +65,7 @@ namespace FSV.ViewModel.UnitTest
             DataTable exportTable = sut.GetPrincipalMembershipDataTable(vm);
 
             Assert.IsNotNull(exportTable);
-            Assert.AreEqual(vm.Groups.Count, exportTable.Rows.Count);
+            Assert.HasCount(vm.Groups.Count, exportTable.Rows);
         }
 
         private IServiceProvider ConfigureAllServices(ServiceCollection services)

--- a/sourcecodes/FSV.ViewModel.UnitTest/SharedServerViewModelTest.cs
+++ b/sourcecodes/FSV.ViewModel.UnitTest/SharedServerViewModelTest.cs
@@ -1,5 +1,5 @@
 // FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
-// Copyright (C) 2015 - 2024  Carsten Sch‰fer, Matthias Friedrich, and Ritesh Gite
+// Copyright (C) 2015 - 2024  Carsten Sch√§fer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -43,7 +43,7 @@ namespace FSV.ViewModel.UnitTest
 
             sut.ListSharesCommand.Execute(null);
 
-            Assert.AreEqual(2, sut.Shares.Count);
+            Assert.HasCount(2, sut.Shares);
         }
 
         private ServerItem GetServer()
@@ -91,7 +91,7 @@ namespace FSV.ViewModel.UnitTest
 
         private Mock<IShareScanner> GetMockShareScanner()
         {
-            Share GetShare(string server, string name)
+            static Share GetShare(string name)
             {
                 return new Share
                 {
@@ -104,7 +104,19 @@ namespace FSV.ViewModel.UnitTest
                 };
             }
 
-            IList<Share> GetSharesOfServer(string server)
+            var mockShareScanner = new Mock<IShareScanner>();
+            mockShareScanner.Setup(m => m.GetShare(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns((string _, string name) => GetShare(name));
+
+            mockShareScanner.Setup(m => m.GetShareAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns((string _, string name) => Task.FromResult(GetShare(name)));
+
+            mockShareScanner.Setup(m => m.GetSharesOfServerAsync(It.IsAny<string>()))
+                .Returns((string _) => Task.FromResult(GetSharesOfServer()));
+
+            return mockShareScanner;
+
+            static IList<Share> GetSharesOfServer()
             {
                 return new List<Share>
                 {
@@ -128,18 +140,6 @@ namespace FSV.ViewModel.UnitTest
                     }
                 };
             }
-
-            var mockShareScanner = new Mock<IShareScanner>();
-            mockShareScanner.Setup(m => m.GetShare(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns((string server, string name) => GetShare(server, name));
-
-            mockShareScanner.Setup(m => m.GetShareAsync(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns((string server, string name) => Task.FromResult(GetShare(server, name)));
-
-            mockShareScanner.Setup(m => m.GetSharesOfServerAsync(It.IsAny<string>()))
-                .Returns((string server) => Task.FromResult(GetSharesOfServer(server)));
-
-            return mockShareScanner;
         }
 
         private Mock<IDispatcherService> GetMockDispatcherService()
@@ -164,7 +164,7 @@ namespace FSV.ViewModel.UnitTest
 
             mockShareServersManager
                 .Setup(m => m.CreateShare(It.IsAny<ServerItem>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Returns((ServerItem server, string name, string path) => new ShareItem(name, path));
+                .Returns((ServerItem _, string name, string path) => new ShareItem(name, path));
 
             return mockShareServersManager;
         }

--- a/sourcecodes/FSV.ViewModel.UnitTest/TemplateContainerViewModelTest.cs
+++ b/sourcecodes/FSV.ViewModel.UnitTest/TemplateContainerViewModelTest.cs
@@ -1,5 +1,5 @@
 // FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
-// Copyright (C) 2015 - 2024  Carsten Sch‰fer, Matthias Friedrich, and Ritesh Gite
+// Copyright (C) 2015 - 2024  Carsten Sch√§fer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -50,7 +50,7 @@ namespace FSV.ViewModel.UnitTest
 
             _ = sut.ShowTemplateEditor(TemplateType.PermissionReport, "some/test/path");
 
-            Assert.AreEqual(3, sut.Templates.Count);
+            Assert.HasCount(3, sut.Templates);
             Assert.AreEqual(TestTemplateName, sut.Templates.Last().Name);
         }
 
@@ -68,7 +68,7 @@ namespace FSV.ViewModel.UnitTest
 
             sut.RemoveTemplateCommand.Execute(null);
 
-            Assert.AreEqual(1, sut.Templates.Count);
+            Assert.HasCount(1, sut.Templates);
             Assert.AreEqual("Three One", sut.Templates.First().Name);
         }
 
@@ -119,7 +119,7 @@ namespace FSV.ViewModel.UnitTest
                 </Templates>";
 
             XDocument document = XDocument.Parse(xml);
-            List<Template> templateList = document.Root.Elements().Select(el => new Template(el)).ToList();
+            List<Template> templateList = document.Root!.Elements().Select(el => new Template(el)).ToList();
 
             var mock = new Mock<ITemplateFile>();
             mock.SetupGet(m => m.Templates)

--- a/sourcecodes/FSV.ViewModel/AdMembers/GroupMemberItemViewModel.cs
+++ b/sourcecodes/FSV.ViewModel/AdMembers/GroupMemberItemViewModel.cs
@@ -1,5 +1,5 @@
 // FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.
-// Copyright (C) 2015 - 2024  Carsten Sch‰fer, Matthias Friedrich, and Ritesh Gite
+// Copyright (C) 2015 - 2024  Carsten Sch√§fer, Matthias Friedrich, and Ritesh Gite
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -32,7 +32,9 @@ namespace FSV.ViewModel.AdMembers
 
             this.AccountName = member.SamAccountName;
             this.AccountType = member.IsGroup ? GroupMemberResource.GroupText : GroupMemberResource.UserText;
-            this.OU = string.Join("/", member.Ou.Split('/').Reverse());
+            string[] strings = member.Ou.Split('/');
+            strings.Reverse();
+            this.OU = string.Join("/", strings);
             this.Domain = member.DomainName;
             this.DisplayName = member.DisplayName;
             this.IsGroup = member.IsGroup;

--- a/sourcecodes/FSV.ViewModel/FSV.ViewModel.csproj
+++ b/sourcecodes/FSV.ViewModel/FSV.ViewModel.csproj
@@ -20,11 +20,11 @@
   <PropertyGroup>
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FSV.ViewModel</AssemblyTitle>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
     <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
-    <FileVersion>2.8.1</FileVersion>
+    <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>
     <Product>FolderSecurityViewer</Product>
   </PropertyGroup>

--- a/sourcecodes/FSV.ViewModel/FSV.ViewModel.csproj
+++ b/sourcecodes/FSV.ViewModel/FSV.ViewModel.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Prism.Core">
-      <Version>8.1.97</Version>
+      <Version>9.0.537</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/sourcecodes/FSV.ViewModel/FSV.ViewModel.csproj
+++ b/sourcecodes/FSV.ViewModel/FSV.ViewModel.csproj
@@ -22,7 +22,7 @@
     <AssemblyTitle>FSV.ViewModel</AssemblyTitle>
     <AssemblyVersion>2.9.0</AssemblyVersion>
     <Company>G-TAC Software UG, Katzweiler, Germany</Company>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>Part of G-TAC's NTFS Permissions Reporter "FolderSecurityViewer"</Description>
     <FileVersion>2.9.0</FileVersion>
     <NeutralLanguage>en</NeutralLanguage>

--- a/sourcecodes/FSV.ViewModel/FSV.ViewModel.csproj
+++ b/sourcecodes/FSV.ViewModel/FSV.ViewModel.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWPF>true</UseWPF>

--- a/sourcecodes/FolderSecurityViewer.UnitTest/FolderSecurityViewer.UnitTest.csproj
+++ b/sourcecodes/FolderSecurityViewer.UnitTest/FolderSecurityViewer.UnitTest.csproj
@@ -9,7 +9,7 @@
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
     <Product>FolderSecurityViewer.UnitTest</Product>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\FolderSecurityViewer\FolderSecurityViewer.csproj" />

--- a/sourcecodes/FolderSecurityViewer.UnitTest/FolderSecurityViewer.UnitTest.csproj
+++ b/sourcecodes/FolderSecurityViewer.UnitTest/FolderSecurityViewer.UnitTest.csproj
@@ -3,7 +3,7 @@
     <AnalysisLevel>none</AnalysisLevel>
     <AssemblyTitle>FolderSecurityViewer.UnitTest</AssemblyTitle>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <FileVersion>1.0.0.0</FileVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>latest</LangVersion>

--- a/sourcecodes/FolderSecurityViewer.UnitTest/FolderSecurityViewer.UnitTest.csproj
+++ b/sourcecodes/FolderSecurityViewer.UnitTest/FolderSecurityViewer.UnitTest.csproj
@@ -15,17 +15,17 @@
     <ProjectReference Include="..\FolderSecurityViewer\FolderSecurityViewer.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">
-      <Version>17.10.0</Version>
+      <Version>18.0.1</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.9.0</Version>
+      <Version>2.9.3</Version>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/sourcecodes/FolderSecurityViewer.sln
+++ b/sourcecodes/FolderSecurityViewer.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.10.35027.167
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11205.157 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FSV.FolderTree", "FSV.FolderTree\FSV.FolderTree.csproj", "{FD1D8BAE-014C-4941-BA49-33182955689C}"
 EndProject
@@ -306,7 +306,7 @@ Global
 		{546EB7C8-691A-4D3F-844D-B92486C3CF7A} = {0E252AB3-1E8E-4FE2-82FC-C207CA1B5970}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		VisualSVNWorkingCopyRoot = .
 		SolutionGuid = {CD022600-DA06-4B78-B1B4-7B3B1F02C19B}
+		VisualSVNWorkingCopyRoot = .
 	EndGlobalSection
 EndGlobal

--- a/sourcecodes/FolderSecurityViewer/FolderSecurityViewer.csproj
+++ b/sourcecodes/FolderSecurityViewer/FolderSecurityViewer.csproj
@@ -13,9 +13,9 @@
     <Title>FolderSecurityViewer</Title>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
-    <Version>2.8.1</Version>
-    <AssemblyVersion>2.8.1</AssemblyVersion>
-    <FileVersion>2.8.1</FileVersion>
+    <Version>2.9.0</Version>
+    <AssemblyVersion>2.9.0</AssemblyVersion>
+    <FileVersion>2.9.0</FileVersion>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/sourcecodes/FolderSecurityViewer/FolderSecurityViewer.csproj
+++ b/sourcecodes/FolderSecurityViewer/FolderSecurityViewer.csproj
@@ -69,25 +69,25 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf">
-      <Version>1.1.122</Version>
+      <Version>1.1.135</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Extensions.Logging">
-      <Version>8.0.0</Version>
+      <Version>9.0.2</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.File">
-      <Version>6.0.0</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="Serilog.Sinks.SQLite">
       <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="System.Data.SQLite">
-      <Version>1.0.118</Version>
+      <Version>2.0.2</Version>
     </PackageReference>
     <PackageReference Include="System.IO.Abstractions">
-      <Version>21.0.26</Version>
+      <Version>22.0.16</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Views\Home\TreeView.xaml.cs" />

--- a/sourcecodes/FolderSecurityViewer/FolderSecurityViewer.csproj
+++ b/sourcecodes/FolderSecurityViewer/FolderSecurityViewer.csproj
@@ -9,7 +9,7 @@
     <PublishUrl>publish\</PublishUrl>
     <RestorePackages>true</RestorePackages>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <Title>FolderSecurityViewer</Title>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>

--- a/sourcecodes/FolderSecurityViewer/FolderSecurityViewer.csproj
+++ b/sourcecodes/FolderSecurityViewer/FolderSecurityViewer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Authors>Carsten Schäfer, Matthias Friedrich, and Ritesh Gite</Authors>
-    <Copyright>Copyright © 2015 - 2024 G-TAC Software UG</Copyright>
+    <Copyright>Copyright © 2015 - 2025 G-TAC Software UG</Copyright>
     <Description>FolderSecurityViewer is an easy-to-use NTFS permissions tool that helps you effectively trace down all security owners of your data.</Description>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Upgrade to .NET 9.0 and update project metadata

This pull request upgrades the entire FolderSecurityViewer solution to .NET 9.0. This is a major framework upgrade that modernizes the codebase, enabling access to .NET 9.0 features and performance improvements.

## Changes

### .NET Framework Migration

- **Upgraded all projects** from .NET 8.0 to .NET 9.0
- Updated both standard (.NET 9.0) and Windows-specific (.NET 9.0-windows) target frameworks
- Modified CI/CD pipeline to build and test against .NET 9.0, and enabled dependency caching to improve build performance

### Version Updates

- **Bumped version** from 2.8.1 to 2.9.0 across all projects
- Updated `AssemblyVersion` and `FileVersion` properties consistently